### PR TITLE
激活三个「有存储但从不生效」的字段，并修权限策略本体维度缺陷

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -232,10 +232,10 @@ cd frontend && npm install && npm run dev
 | Agent roles derived from onboarded domains | ✅ | `agent_roles.py` |
 | Operation preflight and HTTP writeback | ✅ | `automation.py` |
 | JSON-LD / Turtle export | ✅ | `ontology.py` |
-| Workflow `guard_expression` | ⚠️ | stored and exposed, **never evaluated** |
-| Permission `filter_expression` | ⚠️ | stored, `check_permission` **returns it verbatim** |
-| Rule `depends_on` | ⚠️ | read and written, **unused** during evaluation |
-| Permission policy ontology dimension | ⚠️ | keyed on bare `object_code`; same-named objects **share a policy** |
+| Workflow `guard_expression` | ✅ | evaluated on transition, fail-closed |
+| Permission `filter_expression` | ✅ | evaluated when an instance is supplied |
+| Rule `depends_on` | ✅ | topologically ordered; dependents skip when a prerequisite fails |
+| Permission policy ontology dimension | ✅ | keyed on (role, ontology, object); 0 means any |
 | Manual CRUD for objects/attributes/relations | ⚠️ | no endpoints |
 | List endpoint pagination | ⚠️ | mostly absent |
 | Document knowledge base (clause chunking, citations) | ✅ | `knowledge_documents.py` |
@@ -339,7 +339,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**283 tests**, all passing:
+**311 tests**, all passing:
 
 | File | Count | Covers |
 |---|--:|---|
@@ -349,6 +349,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 | `test_custom_model_endpoints.py` | 21 | custom model endpoint compatibility |
 | `test_workbench_and_graph.py` | 14 | workbench aggregation and graph projection |
 | `test_document_knowledge.py` | 27 | clause chunking, anchored retrieval, cited answers |
+| `test_inert_fields_activated.py` | 28 | guards, row filters, rule dependencies, policy scoping |
 | `test_metadata_flow.py` | 34 | onboarding, scanning, drafting, readiness |
 | `test_api_authentication.py` | 27 | auth, sessions, capability policy, trusted actor |
 | `test_domain_neutrality.py` | 25 | unknown domain end to end, plus static guards |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ flowchart TB
 | 决策留痕四层记录 | ✅ | `decisions.py`、`semantic_kernel.py` |
 | 语义覆盖度报告 | ✅ | `coverage.py` |
 | 实例工作流状态与历史 | ✅ | `workflow_permission.py` |
-| 工作流 `guard_expression` | ⚠️ | 有存储有接口，transition 时**从不求值** |
+| 工作流 `guard_expression` | ✅ | transition 时真实求值，fail-closed |
 | 工作流与本体版本联动 | ⚠️ | derive 新版本**不复制**工作流配置 |
 | 列表端点分页 | ⚠️ | 基本无分页（audit-log 等少数除外） |
 
@@ -329,8 +329,8 @@ flowchart TB
 | **插件可注册路由权限策略** | ✅ | `access_policy.py` |
 | 审计 actor 取自认证身份，不接受客户端自报 | ✅ | `api.py`、`auth.py` |
 | 凭据脱敏（连接串密码段、API Key 首尾） | ✅ | `credentials.py` |
-| 权限行级过滤 `filter_expression` | ⚠️ | 有存储，`check_permission` **只原样返回** |
-| 权限策略本体维度 | ⚠️ | 只按裸 `object_code` 索引，**同名对象共享策略**（已知缺陷） |
+| 权限行级过滤 `filter_expression` | ✅ | `check_permission` 传入实例时真实求值 |
+| 权限策略本体维度 | ✅ | 按 `(role, ontology, object)` 索引，0 表示通配 |
 | 多租户／租户隔离 | 📋 | 31 张表零租户概念 |
 | 数据字典、部门／岗位数据权限 | 📋 | — |
 
@@ -369,13 +369,10 @@ flowchart TB
 
 这类最危险，因为接口看起来能用：
 
-- **`workflow_transition.guard_expression`** —— 有存储有接口，transition 时从不求值。
-  不要依赖它做状态流转准入。
-- **`permission_policy.filter_expression`** —— 有存储，`check_permission` 只原样返回，
-  不做行级过滤。不要依赖它做数据隔离。
-- **`business_rule.depends_on`** —— 有读写，求值时完全不用，只按 `priority` 排序。
-- **`permission_policy` 缺本体维度** —— 只按裸 `object_code` 建索引，
-  两个本体定义同名对象时会共享同一条策略。**已知缺陷。**
+> 此前列在本节的四项已修复：`guard_expression`、`filter_expression`、
+> `depends_on` 现已真实生效，`permission_policy` 已带本体维度。三者均为
+> fail-closed：无法求值时拒绝而非放行。
+
 - **工作流与本体版本脱钩** —— `derive` 新版本不复制工作流配置。
 - **元模型文档超前** —— `docs/02` 画了 Event 与 State，schema 中无对应表。
 
@@ -529,7 +526,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**283 个测试**，全绿。分布：
+**311 个测试**，全绿。分布：
 
 | 文件 | 数量 | 覆盖 |
 |---|--:|---|
@@ -539,6 +536,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_custom_model_endpoints.py` | 21 | 自定义模型端点兼容性 |
 | `test_workbench_and_graph.py` | 14 | 工作台聚合与图谱投影 |
 | `test_document_knowledge.py` | 27 | 条款切分、锚定检索、带引用答案 |
+| `test_inert_fields_activated.py` | 28 | 守卫、行级过滤、规则依赖、策略本体维度 |
 | `test_metadata_flow.py` | 34 | 接入、扫描、本体生成、接入准备度 |
 | `test_api_authentication.py` | 27 | 认证、会话、能力策略、actor 可信 |
 | `test_domain_neutrality.py` | 25 | 未知领域全链路 + 静态守卫 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,13 +51,14 @@
 
 这些是当前设计的边界，**不是漏洞**，但部署时必须知道：
 
-- `permission_policy.filter_expression` 有存储但**未生效**：
-  `check_permission` 只原样返回该表达式，不做行级过滤。
-  不要依赖它做数据隔离。
-- `workflow_transition.guard_expression` 有存储但**转移时从不求值**。
-  不要依赖它做状态流转的准入控制。
-- `permission_policy` 只按裸 `object_code` 建索引，**无本体维度**：
-  两个本体定义同名对象时会共享同一条策略。
+- `permission_policy.filter_expression` **现已生效**：向 `check_permission`
+  传入 `instance_id` 时会在规则沙箱中求值，无法求值则拒绝访问。
+  **但仍需注意**：不传 `instance_id` 时只做能力校验，返回的
+  `filterApplied: False` 表示行级过滤未参与判断——调用方必须检查该字段。
+- `workflow_transition.guard_expression` **现已生效**：transition 时求值，
+  无法求值则阻止流转。
+- `permission_policy` 现按 `(role_id, ontology_id, object_code)` 建索引。
+  `ontology_id = 0` 表示通配，用于兼容既有单本体部署。
 - **无多租户隔离。** 31 张表没有租户概念，一个部署实例服务一个组织。
 - `ONTOLOGY_AUTH_DISABLED=1` 会关闭全部认证，使所有接口可匿名访问。
   仅限本地开发；启用时启动日志会打印警告。

--- a/backend/ontology_platform/database.py
+++ b/backend/ontology_platform/database.py
@@ -517,6 +517,17 @@ COLUMN_MIGRATIONS: tuple[ColumnMigration, ...] = (
         "integer not null default 1",
         "integer not null default 1",
     ),
+    # permission_policy previously keyed on a bare object_code, so two ontologies
+    # defining the same code shared one policy row. Existing rows get 0, meaning
+    # "any ontology", which preserves their current behaviour; new rows carry a
+    # real ontology id.
+    ColumnMigration(
+        "permission_policy",
+        "ontology_id",
+        "integer not null default 0",
+        "integer not null default 0",
+        "integer not null default 0",
+    ),
 )
 
 

--- a/backend/ontology_platform/semantic_kernel.py
+++ b/backend/ontology_platform/semantic_kernel.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Sequence
 
 from .adapters import RuntimeDatabase, get_adapter
 from .config import clamp_page_size, clamp_sample_size
@@ -16,6 +17,8 @@ from .decisions import record_decision_in_connection
 from .ontology import explain_instance
 from .registry import Registry, load_entry_point_plugins
 from .value_mapping import load_value_mappings_in_connection, state_for
+
+logger = logging.getLogger(__name__)
 
 
 class RowObject:
@@ -229,9 +232,24 @@ def assess_instance(platform_db: Path | str, ontology_id: int, object_code: str,
             (ontology_id, object_code, today, today),
         ).fetchall()
 
+        # Honour declared dependencies. `depends_on` was read and written but
+        # never used during evaluation, so a rule that only makes sense after a
+        # prerequisite passed could run first and produce a misleading failure.
+        rules = order_rules_by_dependency(rules)
+        satisfied: set[str] = set()
+
         results = []
         for rule in rules:
-            passed, error = _evaluate_rule(rule["expression"], runtime.context)
+            blocked_by = _unsatisfied_dependencies(rule, satisfied)
+            passed: bool
+            error: str | None
+            if blocked_by:
+                # A dependency that did not pass makes this rule's verdict
+                # meaningless, so report it as not passed with the reason rather
+                # than evaluating it against a precondition known to be false.
+                passed, error = False, (f"前置规则未通过：{'、'.join(blocked_by)}")
+            else:
+                passed, error = _evaluate_rule(rule["expression"], runtime.context)
             skipped = error is not None
             # Fail closed: an expression that cannot be evaluated (renamed
             # column, type mismatch, bad syntax) must not be reported as a
@@ -295,6 +313,8 @@ def assess_instance(platform_db: Path | str, ontology_id: int, object_code: str,
                     "naturalLanguage": rule["natural_language"],
                 }
             )
+            if decision_passed:
+                satisfied.add(rule["code"])
 
         failed = [result for result in results if not result["passed"]]
         decision = _decision_from_results(failed)
@@ -575,6 +595,91 @@ def _load_related_context(
         related[foreign_key["child_table"]] = RelatedRows(rows)
 
     return related
+
+
+def parse_depends_on(raw: Any) -> list[str]:
+    """Read the stored dependency list, tolerating malformed values.
+
+    Stored as a JSON array of rule codes. A malformed value degrades to "no
+    dependencies" rather than breaking assessment: losing an ordering hint is
+    recoverable, refusing to evaluate any rule is not.
+    """
+    if not raw:
+        return []
+    if isinstance(raw, (list, tuple)):
+        return [str(code).strip() for code in raw if str(code).strip()]
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(code).strip() for code in parsed if str(code).strip()]
+
+
+def order_rules_by_dependency(rules: Sequence[Any]) -> list[Any]:
+    """Topologically order rules so prerequisites evaluate first.
+
+    Ties keep the existing ordering (priority desc, severity, code), so behaviour
+    is unchanged for the common case where nothing declares a dependency.
+
+    Cycles are broken rather than raised: a cyclic declaration is a modelling
+    mistake, but refusing to assess the instance at all would turn a bad hint into
+    an outage. Rules in a cycle are appended in their original order and the cycle
+    is logged.
+    """
+    by_code = {rule["code"]: rule for rule in rules}
+    remaining = list(rules)
+    ordered: list[Any] = []
+    placed: set[str] = set()
+
+    while remaining:
+        progressed = False
+        deferred = []
+        for rule in remaining:
+            # Only dependencies that exist in this scope can gate ordering; a
+            # reference to an unknown or out-of-scope code is ignored here and
+            # surfaced at evaluation time instead.
+            pending = [
+                code
+                for code in parse_depends_on(rule["depends_on"] if "depends_on" in rule.keys() else None)  # noqa: SIM118
+                if code in by_code and code not in placed and code != rule["code"]
+            ]
+            if pending:
+                deferred.append(rule)
+            else:
+                ordered.append(rule)
+                placed.add(rule["code"])
+                progressed = True
+        if not progressed:
+            logger.warning(
+                "规则依赖存在循环，已按原顺序追加: %s",
+                "、".join(str(rule["code"]) for rule in deferred),
+            )
+            ordered.extend(deferred)
+            break
+        remaining = deferred
+    return ordered
+
+
+def _unsatisfied_dependencies(rule: Any, satisfied: set[str]) -> list[str]:
+    """Declared prerequisites that have not passed in this run."""
+    declared = parse_depends_on(rule["depends_on"] if "depends_on" in rule.keys() else None)  # noqa: SIM118
+    return [code for code in declared if code and code not in satisfied]
+
+
+def evaluate_rule_expression(expression: str, context: dict[str, Any]) -> tuple[bool, str | None]:
+    """Evaluate an expression in the rule sandbox.
+
+    Public entry point for callers outside the rule engine -- currently workflow
+    transition guards. Exposed deliberately rather than letting other modules
+    reach for the private `_evaluate_rule`, so there is exactly one sandbox to
+    audit and guards inherit its hardening.
+
+    Returns (passed, error). A non-None error means the expression could not be
+    evaluated; callers are expected to treat that as *not passed* (ADR-0002).
+    """
+    return _evaluate_rule(expression, context)
 
 
 def _evaluate_rule(expression: str, context: dict[str, Any]) -> tuple[bool, str | None]:

--- a/backend/ontology_platform/workflow_permission.py
+++ b/backend/ontology_platform/workflow_permission.py
@@ -21,6 +21,69 @@ def _uuid() -> str:
     return uuid.uuid4().hex[:16]
 
 
+def _row_value(row: Any, column: str, default: Any = None) -> Any:
+    """Read a column that an older schema may not have.
+
+    Guard and filter expressions were added by migration, so a database created
+    by an earlier build can legitimately lack them.
+    """
+    try:
+        value = row[column]
+    except (KeyError, IndexError, TypeError):
+        return default
+    return default if value is None else value
+
+
+def _evaluate_guard(
+    platform_db: Path | str,
+    expression: str,
+    *,
+    ontology_id: int,
+    object_code: str,
+    instance_id: str,
+) -> dict[str, Any]:
+    """Evaluate a transition guard against the instance's live data.
+
+    Reuses the rule engine's AST-allowlist sandbox rather than adding a second
+    expression evaluator: one sandbox to audit, and guards automatically inherit
+    every hardening applied there.
+
+    Fail-closed, per ADR-0002. If the instance cannot be loaded or the expression
+    cannot be evaluated, the guard does not pass. A guard that silently succeeds
+    when its data is missing is worse than no guard, because operators believe the
+    gate is active.
+    """
+    from .semantic_kernel import build_runtime, evaluate_rule_expression
+
+    if not object_code:
+        return {
+            "expression": expression,
+            "passed": False,
+            "reason": "工作流未绑定业务对象，无法求值流转守卫。",
+        }
+    try:
+        with connect(platform_db) as data_conn:
+            runtime = build_runtime(data_conn, ontology_id, object_code, instance_id)
+        passed, error = evaluate_rule_expression(expression, runtime.context)
+    except Exception as error:
+        return {
+            "expression": expression,
+            "passed": False,
+            "reason": f"守卫求值失败（已按未通过处理）: {error}",
+        }
+    if error is not None:
+        return {
+            "expression": expression,
+            "passed": False,
+            "reason": f"守卫表达式无法求值（已按未通过处理）: {error}",
+        }
+    return {
+        "expression": expression,
+        "passed": bool(passed),
+        "reason": "守卫条件满足。" if passed else "守卫条件不满足。",
+    }
+
+
 SCHEMA_SQL: tuple[dict[str, str], ...] = (
     {
         "sqlite": """
@@ -256,7 +319,8 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             can_delete integer not null default 0,
             filter_expression text not null default '',
             description text not null default '',
-            unique(role_id, object_code)
+            ontology_id integer not null default 0,
+            unique(role_id, ontology_id, object_code)
         )""",
         "postgresql": """
         create table if not exists permission_policy (
@@ -269,7 +333,8 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             can_delete boolean not null default false,
             filter_expression text not null default '',
             description text not null default '',
-            unique(role_id, object_code)
+            ontology_id integer not null default 0,
+            unique(role_id, ontology_id, object_code)
         )""",
         "mysql": """
         create table if not exists permission_policy (
@@ -282,7 +347,8 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             can_delete tinyint not null default 0,
             filter_expression text not null default (''),
             description text not null default (''),
-            unique(role_id, object_code)
+            ontology_id integer not null default 0,
+            unique key uniq_policy (role_id, ontology_id, object_code)
         )""",
     },
     {
@@ -661,6 +727,30 @@ def transition_instance(
         if transition is None:
             raise ValueError(f"当前状态 '{current}' 不允许执行动作 '{action_code}'")
         to_state = transition["to_state"]
+
+        # Evaluate the transition guard. This field was previously stored and
+        # exposed through the API but never evaluated, so a workflow that looked
+        # gated was not. Fail-closed like the rule engine (ADR-0002): a guard that
+        # cannot be evaluated blocks the transition rather than waving it through,
+        # because the alternative silently disables a control that operators
+        # believe is active.
+        guard = (_row_value(transition, "guard_expression") or "").strip()
+        guard_result: dict[str, Any] | None = None
+        if guard:
+            workflow = conn.execute(
+                "select ontology_id, object_code from workflow_definition where id = ?",
+                (workflow_id,),
+            ).fetchone()
+            guard_result = _evaluate_guard(
+                platform_db,
+                guard,
+                ontology_id=int(workflow["ontology_id"]) if workflow else 0,
+                object_code=workflow["object_code"] if workflow else "",
+                instance_id=instance_id,
+            )
+            if not guard_result["passed"]:
+                raise ValueError(f"流转守卫未通过，动作 '{action_code}' 被阻止：{guard_result['reason']}")
+
         now = _now()
         conn.execute(
             "update instance_workflow set current_state = ?, state_entered_at = ?, updated_at = ? where id = ?",
@@ -668,7 +758,21 @@ def transition_instance(
         )
         conn.execute(
             "insert into workflow_history (instance_workflow_id, from_state, to_state, action_code, actor, reason, metadata) values (?, ?, ?, ?, ?, ?, ?)",
-            (iw_id, current, to_state, action_code, actor, reason, json.dumps(metadata or {}, ensure_ascii=False)),
+            (
+                iw_id,
+                current,
+                to_state,
+                action_code,
+                actor,
+                reason,
+                json.dumps(
+                    # Record the guard outcome so an auditor can see the gate ran
+                    # and on what data, not merely that the transition happened.
+                    {**(metadata or {}), **({"guard": guard_result} if guard_result else {})},
+                    ensure_ascii=False,
+                    default=str,
+                ),
+            ),
         )
         conn.commit()
         return _get_instance_state(conn, iw_id)
@@ -785,16 +889,24 @@ def upsert_permission_policy(
     can_delete: bool = False,
     filter_expression: str = "",
     description: str = "",
+    ontology_id: int = 0,
 ) -> dict[str, Any]:
+    """Create or update an object-level policy.
+
+    `ontology_id` defaults to 0, meaning "any ontology". That keeps existing
+    single-ontology deployments working unchanged while allowing two ontologies
+    that define the same object code to hold distinct policies -- the defect
+    recorded in docs/architecture-debt.md.
+    """
     with connect(platform_db) as conn:
         existing = conn.execute(
-            "select id from permission_policy where role_id = ? and object_code = ?",
-            (role_id, object_code),
+            "select id from permission_policy where role_id = ? and object_code = ? and ontology_id = ?",
+            (role_id, object_code, ontology_id),
         ).fetchone()
         if existing:
             conn.execute(
                 """update permission_policy set can_read=?, can_write=?, can_execute=?, can_delete=?,
-                filter_expression=?, description=? where role_id=? and object_code=?""",
+                filter_expression=?, description=? where role_id=? and object_code=? and ontology_id=?""",
                 (
                     1 if can_read else 0,
                     1 if can_write else 0,
@@ -804,12 +916,13 @@ def upsert_permission_policy(
                     description,
                     role_id,
                     object_code,
+                    ontology_id,
                 ),
             )
         else:
             conn.execute(
-                """insert into permission_policy (role_id, object_code, can_read, can_write, can_execute, can_delete, filter_expression, description)
-                values (?, ?, ?, ?, ?, ?, ?, ?)""",
+                """insert into permission_policy (role_id, object_code, can_read, can_write, can_execute, can_delete, filter_expression, description, ontology_id)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     role_id,
                     object_code,
@@ -819,6 +932,7 @@ def upsert_permission_policy(
                     1 if can_delete else 0,
                     filter_expression,
                     description,
+                    ontology_id,
                 ),
             )
         conn.commit()
@@ -834,15 +948,38 @@ def check_permission(
     role_code: str,
     object_code: str,
     operation: str = "read",
+    *,
+    ontology_id: int | None = None,
+    instance_id: str = "",
 ) -> dict[str, Any]:
+    """Decide whether a role may perform an operation on an object.
+
+    When `instance_id` is supplied and the policy carries a row filter, the filter
+    is actually evaluated against that instance. Previously the expression was
+    returned verbatim and never applied, which meant a deployment could believe it
+    had row-level isolation while having none -- the reason this was flagged in
+    SECURITY.md rather than merely listed as unfinished.
+
+    Callers that omit `instance_id` get `filterExpression` plus
+    `filterApplied: False`, so "I did not evaluate this" is distinguishable from
+    "there was nothing to evaluate".
+    """
     with connect(platform_db) as conn:
         role = conn.execute("select id from permission_role where code = ?", (role_code,)).fetchone()
         if role is None:
             return {"allowed": False, "reason": f"角色 '{role_code}' 不存在"}
-        policy = conn.execute(
-            "select * from permission_policy where role_id = ? and object_code = ?",
-            (int(role["id"]), object_code),
-        ).fetchone()
+        # Prefer a policy scoped to this ontology over the wildcard (ontology_id
+        # 0), so two ontologies sharing an object code no longer share a policy.
+        # Ordering by ontology_id desc puts the specific match first.
+        candidates = conn.execute(
+            """
+            select * from permission_policy
+            where role_id = ? and object_code = ? and ontology_id in (?, 0)
+            order by ontology_id desc
+            """,
+            (int(role["id"]), object_code, ontology_id or 0),
+        ).fetchall()
+        policy = candidates[0] if candidates else None
         if policy is None:
             return {"allowed": False, "reason": f"角色 '{role_code}' 对对象 '{object_code}' 无策略"}
         col = f"can_{operation}"
@@ -850,13 +987,69 @@ def check_permission(
         # *values*, not its column names, so removing it would silently deny
         # every permission.
         allowed = bool(policy[col]) if col in policy.keys() else False  # noqa: SIM118
-        return {
-            "allowed": allowed,
-            "roleCode": role_code,
-            "objectCode": object_code,
-            "operation": operation,
-            "filterExpression": policy["filter_expression"] or None,
-        }
+        filter_expression = (_row_value(policy, "filter_expression") or "").strip()
+
+    result: dict[str, Any] = {
+        "allowed": allowed,
+        "roleCode": role_code,
+        "objectCode": object_code,
+        "operation": operation,
+        "filterExpression": filter_expression or None,
+        "filterApplied": False,
+    }
+    if not allowed or not filter_expression:
+        return result
+
+    if not instance_id:
+        # The capability check passed but the row filter has not been evaluated.
+        # Say so explicitly instead of implying a full decision.
+        result["reason"] = "已通过能力校验；未提供实例标识，行级过滤未求值。"
+        return result
+
+    resolved_ontology = ontology_id
+    if resolved_ontology is None:
+        resolved_ontology = _resolve_policy_ontology(platform_db, object_code)
+
+    # Same sandbox and the same fail-closed stance as rule evaluation: a filter
+    # that cannot be evaluated denies access.
+    verdict = _evaluate_guard(
+        platform_db,
+        filter_expression,
+        ontology_id=resolved_ontology or 0,
+        object_code=object_code,
+        instance_id=instance_id,
+    )
+    result["filterApplied"] = True
+    result["instanceId"] = instance_id
+    result["allowed"] = bool(verdict["passed"])
+    result["reason"] = verdict["reason"]
+    return result
+
+
+def _resolve_policy_ontology(platform_db: Path | str, object_code: str) -> int | None:
+    """Find the ontology owning an object code.
+
+    permission_policy is keyed on a bare object_code with no ontology dimension,
+    so two ontologies defining the same code share one policy row. That defect is
+    recorded in README and docs/architecture-debt.md; this resolves the most
+    recently created match and reports ambiguity to the caller's log rather than
+    guessing silently.
+    """
+    with connect(platform_db) as conn:
+        rows = conn.execute(
+            "select ontology_id from business_object where code = ? order by ontology_id desc",
+            (object_code,),
+        ).fetchall()
+    if not rows:
+        return None
+    if len(rows) > 1:
+        logger.warning(
+            "对象编码 %s 在 %d 个本体中重复，权限策略缺少本体维度，已取最新本体 %s。",
+            object_code,
+            len(rows),
+            rows[0]["ontology_id"],
+        )
+    return int(rows[0]["ontology_id"])
 
 
 def list_policies(platform_db: Path | str, role_id: int | None = None) -> list[dict[str, Any]]:

--- a/docs/architecture-debt.md
+++ b/docs/architecture-debt.md
@@ -120,6 +120,10 @@ SQLite 的 `text`）只会在对应后端上暴露。
   → 运行时注册表 + entry points（`registry.py`，ADR-0007）
 - ~~复合主键三处 `raise ValueError`，连接表与版本化表无法建模~~
   → 实例键抽象（`instance_key.py`，ADR-0008）
+- ~~`guard_expression` / `filter_expression` / `depends_on` 有存储但从不求值~~
+  → 三者均已真实生效且 fail-closed（`workflow_permission.py`、`semantic_kernel.py`）
+- ~~`permission_policy` 缺本体维度，同名对象共享策略~~
+  → 按 `(role_id, ontology_id, object_code)` 索引，`0` 为通配以兼容既有部署
 - ~~护城河第三段缺失：无文档检索，判定给不出条款依据~~
   → 锚定本体的文档知识层（`knowledge_documents.py`、`retrieval.py`，ADR-0009）
 - ~~无值域映射，规则只能写魔法值~~

--- a/tests/test_inert_fields_activated.py
+++ b/tests/test_inert_fields_activated.py
@@ -1,0 +1,417 @@
+"""Three fields that were stored but never evaluated.
+
+`guard_expression`, `filter_expression` and `depends_on` all had storage, API
+surface and UI, but no effect. That combination is worse than a missing feature:
+an operator configures a gate, sees it saved, and believes it is active.
+
+`filter_expression` was the most serious -- SECURITY.md had to warn that row-level
+isolation did not exist despite the field being there. These tests pin down that
+each field now changes behaviour, and that all three fail closed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from ontology_platform.database import connect, initialize_platform_db
+from ontology_platform.governance import upsert_business_rule
+from ontology_platform.metadata import register_data_source, scan_data_source
+from ontology_platform.ontology import generate_ontology_draft
+from ontology_platform.semantic_kernel import (
+    assess_instance,
+    order_rules_by_dependency,
+    parse_depends_on,
+)
+from ontology_platform.workflow_permission import (
+    add_workflow_transition,
+    check_permission,
+    create_role,
+    create_workflow,
+    enter_workflow,
+    init_workflow_and_permission_schema,
+    transition_instance,
+    upsert_permission_policy,
+)
+
+
+@pytest.fixture
+def platform(tmp_path: Path):
+    platform_db = tmp_path / "platform.sqlite3"
+    business_db = tmp_path / "business.sqlite3"
+    initialize_platform_db(platform_db)
+
+    conn = sqlite3.connect(business_db)
+    conn.executescript(
+        """
+        create table purchase (
+            id integer primary key,
+            amount numeric not null,
+            approved integer not null default 0,
+            owner text not null default ''
+        );
+        insert into purchase values (1, 5000, 1, 'alice');
+        insert into purchase values (2, 20000, 0, 'bob');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    source = register_data_source(platform_db, "采购系统", "sqlite", str(business_db), domain="采购管理")
+    scan_data_source(platform_db, source.id)
+    ontology = generate_ontology_draft(platform_db, source.id)
+    with connect(platform_db) as c:
+        init_workflow_and_permission_schema(c)
+    return {
+        "platform_db": platform_db,
+        "ontology_id": ontology["ontology"]["id"],
+        "source_id": source.id,
+    }
+
+
+# -- guard_expression --
+
+
+def _workflow_with_guard(platform, guard: str):
+    workflow = create_workflow(
+        platform["platform_db"],
+        platform["ontology_id"],
+        "purchase",
+        "采购审批",
+        initial_state="draft",
+    )
+    workflow_id = workflow["id"]
+    add_workflow_transition(
+        platform["platform_db"],
+        workflow_id,
+        "draft",
+        "approved",
+        "approve",
+        "审批通过",
+        guard_expression=guard,
+    )
+    return workflow_id
+
+
+def test_guard_blocks_a_transition_when_its_condition_fails(platform) -> None:
+    """Previously the guard was stored and ignored, so this transition succeeded."""
+    workflow_id = _workflow_with_guard(platform, "approved == 1")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "2")
+
+    # Purchase 2 has approved = 0.
+    with pytest.raises(ValueError, match="流转守卫未通过"):
+        transition_instance(platform["platform_db"], workflow_id, "2", "approve", actor="tester")
+
+
+def test_guard_allows_a_transition_when_its_condition_holds(platform) -> None:
+    workflow_id = _workflow_with_guard(platform, "approved == 1")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "1")
+
+    state = transition_instance(platform["platform_db"], workflow_id, "1", "approve", actor="tester")
+    assert state["current_state"] == "approved"
+
+
+def test_transition_without_a_guard_is_unaffected(platform) -> None:
+    """Behaviour must not change for the common ungated case."""
+    workflow_id = _workflow_with_guard(platform, "")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "2")
+    state = transition_instance(platform["platform_db"], workflow_id, "2", "approve", actor="tester")
+    assert state["current_state"] == "approved"
+
+
+def test_unevaluable_guard_blocks_rather_than_passes(platform) -> None:
+    """Fail-closed, per ADR-0002: a broken guard must not wave the transition through."""
+    workflow_id = _workflow_with_guard(platform, "no_such_column == 1")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "1")
+    with pytest.raises(ValueError, match="流转守卫未通过"):
+        transition_instance(platform["platform_db"], workflow_id, "1", "approve", actor="tester")
+
+
+def test_guard_cannot_escape_the_rule_sandbox(platform) -> None:
+    """Guards reuse the rule sandbox, so escapes are rejected the same way."""
+    workflow_id = _workflow_with_guard(platform, "__import__('os').system('true') == 0")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "1")
+    with pytest.raises(ValueError, match="流转守卫未通过"):
+        transition_instance(platform["platform_db"], workflow_id, "1", "approve", actor="tester")
+
+
+def test_guard_outcome_is_recorded_in_history(platform) -> None:
+    """An auditor must be able to see the gate ran, not just that it passed."""
+    from ontology_platform.workflow_permission import get_instance_history
+
+    workflow_id = _workflow_with_guard(platform, "approved == 1")
+    enter_workflow(platform["platform_db"], workflow_id, "purchase", "1")
+    transition_instance(platform["platform_db"], workflow_id, "1", "approve", actor="tester")
+
+    history = get_instance_history(platform["platform_db"], workflow_id, "1")
+    entry = next(item for item in history if item.get("action_code") == "approve")
+    assert "guard" in str(entry.get("metadata", "")), entry
+
+
+# -- filter_expression --
+
+
+def _role_with_filter(platform, expression: str, *, can_read: bool = True):
+    role = create_role(platform["platform_db"], "auditor", "审计员")
+    upsert_permission_policy(
+        platform["platform_db"],
+        role["id"],
+        "purchase",
+        can_read=can_read,
+        filter_expression=expression,
+    )
+    return role
+
+
+def test_row_filter_denies_an_instance_that_fails_it(platform) -> None:
+    """This is the security-relevant one: the filter now actually applies."""
+    _role_with_filter(platform, "amount <= 10000")
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read", instance_id="2")
+    assert result["filterApplied"] is True
+    assert result["allowed"] is False, result
+
+
+def test_row_filter_allows_an_instance_that_satisfies_it(platform) -> None:
+    _role_with_filter(platform, "amount <= 10000")
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read", instance_id="1")
+    assert result["filterApplied"] is True
+    assert result["allowed"] is True, result
+
+
+def test_omitting_the_instance_reports_the_filter_as_unevaluated(platform) -> None:
+    """ "I did not evaluate this" must be distinguishable from "nothing to evaluate"."""
+    _role_with_filter(platform, "amount <= 10000")
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read")
+    assert result["filterApplied"] is False
+    assert result["filterExpression"] == "amount <= 10000"
+    assert "未求值" in result["reason"]
+
+
+def test_unevaluable_filter_denies_access(platform) -> None:
+    """Fail-closed: a broken filter must not grant access to every row."""
+    _role_with_filter(platform, "missing_column == 1")
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read", instance_id="1")
+    assert result["allowed"] is False
+    assert result["filterApplied"] is True
+
+
+def test_capability_denial_short_circuits_the_filter(platform) -> None:
+    """No point evaluating a row filter when the operation itself is denied."""
+    _role_with_filter(platform, "amount <= 10000", can_read=False)
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read", instance_id="1")
+    assert result["allowed"] is False
+    assert result["filterApplied"] is False
+
+
+def test_policy_without_a_filter_behaves_as_before(platform) -> None:
+    _role_with_filter(platform, "")
+    result = check_permission(platform["platform_db"], "auditor", "purchase", "read", instance_id="2")
+    assert result["allowed"] is True
+    assert result["filterExpression"] is None
+
+
+# -- depends_on --
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('["a", "b"]', ["a", "b"]),
+        ("[]", []),
+        ("", []),
+        (None, []),
+        ("not json", []),
+        ('{"a": 1}', []),
+        ('["  spaced  "]', ["spaced"]),
+    ],
+)
+def test_depends_on_parsing_tolerates_bad_values(raw, expected) -> None:
+    """A malformed hint must not break assessment entirely."""
+    assert parse_depends_on(raw) == expected
+
+
+class _FakeRule(dict):
+    """Stands in for a sqlite3.Row, which supports keys()."""
+
+    def keys(self):
+        return super().keys()
+
+
+def test_rules_are_ordered_so_prerequisites_run_first() -> None:
+    rules = [
+        _FakeRule(code="b", depends_on='["a"]'),
+        _FakeRule(code="a", depends_on="[]"),
+    ]
+    assert [rule["code"] for rule in order_rules_by_dependency(rules)] == ["a", "b"]
+
+
+def test_ordering_is_stable_when_nothing_declares_dependencies() -> None:
+    """The common case must keep the existing priority/severity ordering."""
+    rules = [_FakeRule(code=code, depends_on="[]") for code in ("x", "y", "z")]
+    assert [rule["code"] for rule in order_rules_by_dependency(rules)] == ["x", "y", "z"]
+
+
+def test_dependency_cycles_are_broken_not_raised() -> None:
+    """A cyclic declaration is a modelling error, not a reason to refuse assessment."""
+    rules = [
+        _FakeRule(code="a", depends_on='["b"]'),
+        _FakeRule(code="b", depends_on='["a"]'),
+    ]
+    ordered = order_rules_by_dependency(rules)
+    assert {rule["code"] for rule in ordered} == {"a", "b"}
+
+
+def test_self_dependency_does_not_deadlock() -> None:
+    rules = [_FakeRule(code="a", depends_on='["a"]')]
+    assert [rule["code"] for rule in order_rules_by_dependency(rules)] == ["a"]
+
+
+def test_a_rule_is_not_evaluated_when_its_prerequisite_failed(platform) -> None:
+    """Previously depends_on was ignored, so the dependent rule ran regardless."""
+    platform_db, ontology_id = platform["platform_db"], platform["ontology_id"]
+    upsert_business_rule(
+        platform_db,
+        ontology_id,
+        code="must_be_approved",
+        name="必须已审批",
+        rule_type="validation",
+        scope_object_code="purchase",
+        expression="approved == 1",
+        severity="blocking",
+        natural_language="采购必须已审批。",
+        actor="test",
+    )
+    upsert_business_rule(
+        platform_db,
+        ontology_id,
+        code="amount_within_limit",
+        name="金额在限额内",
+        rule_type="validation",
+        scope_object_code="purchase",
+        expression="amount <= 10000",
+        severity="warning",
+        natural_language="金额不得超过限额。",
+        depends_on='["must_be_approved"]',
+        actor="test",
+    )
+
+    # Purchase 2 is unapproved, so the prerequisite fails.
+    result = assess_instance(platform_db, ontology_id, "purchase", "2")
+    dependent = next(item for item in result["ruleResults"] if item["ruleCode"] == "amount_within_limit")
+    assert dependent["passed"] is False
+    assert "前置规则未通过" in dependent["evaluationError"], dependent
+
+
+def test_a_dependent_rule_evaluates_normally_once_its_prerequisite_passes(platform) -> None:
+    platform_db, ontology_id = platform["platform_db"], platform["ontology_id"]
+    upsert_business_rule(
+        platform_db,
+        ontology_id,
+        code="must_be_approved",
+        name="必须已审批",
+        rule_type="validation",
+        scope_object_code="purchase",
+        expression="approved == 1",
+        severity="blocking",
+        natural_language="采购必须已审批。",
+        actor="test",
+    )
+    upsert_business_rule(
+        platform_db,
+        ontology_id,
+        code="amount_within_limit",
+        name="金额在限额内",
+        rule_type="validation",
+        scope_object_code="purchase",
+        expression="amount <= 10000",
+        severity="warning",
+        natural_language="金额不得超过限额。",
+        depends_on='["must_be_approved"]',
+        actor="test",
+    )
+
+    # Purchase 1 is approved and within the limit.
+    result = assess_instance(platform_db, ontology_id, "purchase", "1")
+    dependent = next(item for item in result["ruleResults"] if item["ruleCode"] == "amount_within_limit")
+    assert dependent["passed"] is True
+    assert dependent["evaluationError"] == ""
+
+
+# -- permission_policy ontology dimension --
+
+
+def test_same_object_code_in_two_ontologies_no_longer_shares_a_policy(platform) -> None:
+    """The defect recorded in architecture-debt: policies were keyed on a bare code."""
+    role = create_role(platform["platform_db"], "reviewer2", "复核员")
+    upsert_permission_policy(
+        platform["platform_db"],
+        role["id"],
+        "purchase",
+        can_read=True,
+        ontology_id=platform["ontology_id"],
+    )
+    upsert_permission_policy(
+        platform["platform_db"],
+        role["id"],
+        "purchase",
+        can_read=False,
+        ontology_id=platform["ontology_id"] + 999,
+    )
+
+    allowed = check_permission(
+        platform["platform_db"],
+        "reviewer2",
+        "purchase",
+        "read",
+        ontology_id=platform["ontology_id"],
+    )
+    denied = check_permission(
+        platform["platform_db"],
+        "reviewer2",
+        "purchase",
+        "read",
+        ontology_id=platform["ontology_id"] + 999,
+    )
+    assert allowed["allowed"] is True, allowed
+    assert denied["allowed"] is False, denied
+
+
+def test_wildcard_policy_still_applies_when_no_specific_one_exists(platform) -> None:
+    """Existing single-ontology deployments must keep working unchanged."""
+    role = create_role(platform["platform_db"], "legacy", "遗留角色")
+    # ontology_id defaults to 0, meaning "any ontology".
+    upsert_permission_policy(platform["platform_db"], role["id"], "purchase", can_read=True)
+    result = check_permission(
+        platform["platform_db"],
+        "legacy",
+        "purchase",
+        "read",
+        ontology_id=platform["ontology_id"],
+    )
+    assert result["allowed"] is True
+
+
+def test_a_specific_policy_overrides_the_wildcard(platform) -> None:
+    role = create_role(platform["platform_db"], "mixed", "混合角色")
+    upsert_permission_policy(platform["platform_db"], role["id"], "purchase", can_read=True)
+    upsert_permission_policy(
+        platform["platform_db"],
+        role["id"],
+        "purchase",
+        can_read=False,
+        ontology_id=platform["ontology_id"],
+    )
+    result = check_permission(
+        platform["platform_db"],
+        "mixed",
+        "purchase",
+        "read",
+        ontology_id=platform["ontology_id"],
+    )
+    assert result["allowed"] is False, result


### PR DESCRIPTION
## 为什么这批优先

`guard_expression`、`filter_expression`、`depends_on` 都有存储、有 API、有界面，**但没有任何效果**。这比缺失功能更糟:操作员配置了一道闸门,看到保存成功,于是相信它生效了。

其中 `filter_expression` 最严重——SECURITY.md 不得不专门警告「**不要依赖它做数据隔离**」,而字段本身就摆在界面上。

三者现在**全部 fail-closed**(与 ADR-0002 一致):无法求值时拒绝而非放行。反过来做,等于静默关闭一道操作员信任的管控。

## 逐项

### `guard_expression`

transition 提交前对实例实时数据求值,结果写入 `workflow_history`——审计者能看到闸门**执行过、依据什么数据**,而不只是「转移发生了」。

复用规则引擎沙箱(新增公开的 `evaluate_rule_expression()`),而非另写一个求值器:**只有一个沙箱需要审计**,且守卫自动继承其全部加固。已验证守卫中的沙箱逃逸会被同样拒绝。

### `filter_expression`

传入 `instance_id` 时真实求值。不传时返回 `filterApplied: False` 与明确 reason——**「我没有求值」必须与「没有东西要求值」可区分**。此前返回裸 `allowed: True` 而忽略已配置的过滤器,正是误导的来源。能力校验失败时短路,不做无意义求值。

### `depends_on`

拓扑排序使前置规则先执行;前置未通过的规则报告为未通过并附原因,而不是拿一个已知为假的前提去求值。

平局保持既有的 priority/severity/code 顺序,**未声明依赖时行为完全不变**。环被打破并记日志而非抛异常:环是建模错误,但拒绝评估整个实例会把一个坏提示变成一次故障。JSON 格式错误同理降级为「无依赖」。

### `permission_policy` 缺本体维度(已知缺陷)

改为按 `(role_id, ontology_id, object_code)` 索引。`ontology_id = 0` 表示通配,**既有单本体部署零影响**;具体策略优先于通配。三方言 DDL + 列迁移都已处理。

## 验证方式

- [x] **311 tests passed**(新增 28)
- [x] ruff / mypy clean
- [x] **MySQL 8.0 + PostgreSQL 16** 全量通过
- [x] 因涉及 DDL,**额外在真实 MySQL 与 PostgreSQL 实例上验证**了迁移生效与两本体策略隔离(同一 role + 同一 object_code,本体 1 允许、本体 2 拒绝)
- [x] 守卫沙箱逃逸被拒绝、无法求值的守卫阻止流转、无法求值的过滤器拒绝访问——均有测试

## 破坏性变更

无。未配置守卫的流转、未配置过滤器的策略、未声明依赖的规则,行为逐字节不变;`ontology_id` 默认 0 保持既有策略语义。

## 一处修正

两个测试断言写错了而非代码错了:它们期望 `get_instance_history` 与 `_get_instance_state` 返回 camelCase,而这两个函数返回原始 snake_case 行。**改断言,而不是为了迁就猜测去改 API 形状。**

## 文档

README / README.en 的「当前限制」移除这四项;**SECURITY.md 同步更正**,并写明唯一剩余注意事项:不传 `instance_id` 的调用方必须检查 `filterApplied`。