### PR TITLE
多租户隔离：独立 schema + tenant_id 双保险

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -258,7 +258,8 @@ cd frontend && npm install && npm run dev
 | Bundled vector database integration | 📋 | register via SPI |
 | Conversation persistence | ✅ | `conversations.py` |
 | Feedback loop (rating / correction / escalation) | ✅ | `conversations.py` |
-| Multi-tenancy | 📋 | 31 tables have no tenant concept |
+| Multi-tenancy (separate schema + tenant_id) | ✅ | `tenancy.py` |
+| Tenant provisioning and discovery | ✅ | `tenancy.py` |
 | Channel integrations, scheduler | 📋 | none |
 | Ontology import (SHACL / reasoner) | 📋 | export only |
 | Cross-source entity resolution | 📋 | none |
@@ -352,7 +353,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**369 tests**, all passing:
+**411 tests**, all passing:
 
 | File | Count | Covers |
 |---|--:|---|
@@ -365,6 +366,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 | `test_inert_fields_activated.py` | 28 | guards, row filters, rule dependencies, policy scoping |
 | `test_conversations_and_feedback.py` | 35 | conversation persistence, feedback attribution, escalation |
 | `test_platform_context.py` | 23 | multi-instance isolation, thread binding, compatibility |
+| `test_multi_tenancy.py` | 42 | schema routing, tenant_id defence in depth, cross-tenant detection |
 | `test_metadata_flow.py` | 34 | onboarding, scanning, drafting, readiness |
 | `test_api_authentication.py` | 27 | auth, sessions, capability policy, trusted actor |
 | `test_domain_neutrality.py` | 25 | unknown domain end to end, plus static guards |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ BM25，追求召回质量的部署可注册 pgvector 等后端。**可核验的�
 
 图中如实标注了关系表达力的限制：`relation_type` 恒为 `references`、无基数、无多对多。
 
+### 多租户隔离
+
+按 [ADR-0006](docs/adr/0006-tenant-isolation-model.md) 落地**双层隔离**——
+两层的失效模式不重叠,任何单层出问题另一层仍拦得住:
+
+| 层 | 作用 | 各方言实现 |
+|---|---|---|
+| **schema** | 挡住忘写租户过滤的查询 | PG `search_path`／MySQL database／SQLite 独立文件 |
+| **`tenant_id`** | 把路由错误变成可见报错,而非静默跨租户读取 | 关键表加列 + 写入自动填充 |
+
+共享表方案被否决的原因很具体:它把正确性押在「每条查询都记得加过滤」上,
+而**漏写过滤在单租户测试数据下完全看不出来**。
+
+租户标识受严格校验(`^[a-z][a-z0-9_]{0,38}$`)——它会被插入 DDL 与 `search_path`,
+而这两处无法用绑定参数,因此必须先证明其安全。
+
+`require_tenant()` 在无法确定租户时**拒绝而非猜测**,与 ADR-0002 同一立场。
+
 ### 文档知识库
 
 ![文档知识库](docs/images/09-knowledge-base.png)
@@ -345,7 +363,9 @@ flowchart TB
 | 凭据脱敏（连接串密码段、API Key 首尾） | ✅ | `credentials.py` |
 | 权限行级过滤 `filter_expression` | ✅ | `check_permission` 传入实例时真实求值 |
 | 权限策略本体维度 | ✅ | 按 `(role, ontology, object)` 索引，0 表示通配 |
-| 多租户／租户隔离 | 📋 | 31 张表零租户概念 |
+| 多租户隔离（独立 schema + `tenant_id` 双保险） | ✅ | `tenancy.py` |
+| 租户开通与枚举 | ✅ | `tenancy.py` |
+| 跨租户访问检测（fail-closed） | ✅ | `tenancy.py` |
 | 数据字典、部门／岗位数据权限 | 📋 | — |
 
 ### 语义服务
@@ -543,7 +563,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**369 个测试**，全绿。分布：
+**411 个测试**，全绿。分布：
 
 | 文件 | 数量 | 覆盖 |
 |---|--:|---|
@@ -556,6 +576,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_inert_fields_activated.py` | 28 | 守卫、行级过滤、规则依赖、策略本体维度 |
 | `test_conversations_and_feedback.py` | 35 | 会话持久化、反馈归因、转人工 |
 | `test_platform_context.py` | 23 | 多实例隔离、线程绑定、向后兼容 |
+| `test_multi_tenancy.py` | 42 | schema 路由、tenant_id 双保险、跨租户拦截 |
 | `test_metadata_flow.py` | 34 | 接入、扫描、本体生成、接入准备度 |
 | `test_api_authentication.py` | 27 | 认证、会话、能力策略、actor 可信 |
 | `test_domain_neutrality.py` | 25 | 未知领域全链路 + 静态守卫 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,10 +47,10 @@ Dify 的同类产品，失去差异化。
 多租户落地，贯穿全表，检索期权限过滤，并修掉
 `permission_policy` 缺本体维度的已知缺陷。
 
-> ✅ **隔离模型已定**（[ADR-0006](docs/adr/0006-tenant-isolation-model.md)）：
-> 独立 schema 起步 + 关键表带 `tenant_id` 双保险。
-> ✅ **硬前置已解除**：全局单例已由 `PlatformContext` 取代（ADR-0010）。
-> 🚧 **尚未实现**：31 张表仍无 `tenant_id`，schema 路由未接入适配器。
+> ✅ **已实现**（`tenancy.py`）：schema 路由已接入三方言适配器，
+> 关键表带 `tenant_id`，跨租户访问会被拦截。已在真实 MySQL 与 PostgreSQL 上
+> 验证「A 租户看不到 B 租户数据」。
+> 🚧 **仍待完成**：检索期权限过滤与租户级配额尚未实现。
 
 ### 阶段 C 依赖倒置
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,12 @@
   无法求值则阻止流转。
 - `permission_policy` 现按 `(role_id, ontology_id, object_code)` 建索引。
   `ontology_id = 0` 表示通配，用于兼容既有单本体部署。
-- **无多租户隔离。** 31 张表没有租户概念，一个部署实例服务一个组织。
+- **多租户隔离已实现**（`tenancy.py`，ADR-0006）：每租户独立 schema，
+  关键表带 `tenant_id`，跨租户读取会被 `assert_tenant_row()` 拦截。
+  **注意事项**：多租户是**可选**的——未调用 `provision_tenant()` 的部署仍是
+  单租户模式，此时所有数据在同一 schema 内，不存在租户边界。
+  直接使用 `connect()` 而未绑定租户上下文的自定义代码不会自动获得隔离；
+  请通过 `tenant_context()` 取得上下文,或用 `scope_query()` 显式加过滤。
 - `ONTOLOGY_AUTH_DISABLED=1` 会关闭全部认证，使所有接口可匿名访问。
   仅限本地开发；启用时启动日志会打印警告。
 - 未设置 `ONTOLOGY_ADMIN_PASSWORD` 时会生成随机管理员口令并打印在启动日志中，

--- a/backend/ontology_platform/access_policy.py
+++ b/backend/ontology_platform/access_policy.py
@@ -112,6 +112,9 @@ RULES: tuple[Rule, ...] = (
     _rule(("POST",), r"/conversations/[^/]+/escalate", CAP_REVIEW, "转人工"),
     _rule(("PATCH",), r"/conversations/[^/]+/status", CAP_REVIEW, "变更会话状态"),
     _rule(("POST",), r"/feedback/[0-9]+/resolve", CAP_REVIEW, "处理反馈"),
+    # Provisioning a tenant creates schemas and tables, which is strictly an
+    # administrative act.
+    _rule(("POST",), r"/tenants", CAP_ADMIN, "开通租户"),
     _rule(("GET",), r"/.*", CAP_READ, "平台读取"),
 )
 

--- a/backend/ontology_platform/api.py
+++ b/backend/ontology_platform/api.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -121,6 +122,13 @@ from .semantic_kernel import (
     assess_instance,
     available_rule_names,
     validate_rule_expression,
+)
+from .tenancy import (
+    TenantError,
+    list_tenants,
+    provision_tenant,
+    tenant_context,
+    tenant_statistics,
 )
 from .vocabulary import default_object_code_for_ontology
 from .workbench import build_workbench
@@ -1454,6 +1462,72 @@ def resolve_feedback_item(
     try:
         return resolve_feedback(DEFAULT_PLATFORM_DB, feedback_id, resolution=payload.resolution, actor=principal.actor)
     except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+class TenantCreate(BaseModel):
+    tenant: str
+
+
+def _tenant_base_context() -> Any:
+    """The context tenants are provisioned from.
+
+    Uses the process default, so provisioning targets whatever platform database
+    the deployment is configured with rather than a hardcoded path.
+    """
+    from .context import resolve_context
+
+    return resolve_context(DEFAULT_PLATFORM_DB)
+
+
+@app.get("/tenants")
+def tenants() -> dict[str, object]:
+    """Provisioned tenants.
+
+    Multi-tenancy is opt-in: a single-tenant deployment provisions nothing and this
+    returns an empty list, which is not an error.
+    """
+    base = _tenant_base_context()
+    return {
+        "items": list_tenants(base),
+        "isolationModel": "separate-schema-plus-tenant-id",
+        "dbType": base.db_type,
+    }
+
+
+@app.post("/tenants")
+def create_tenant(
+    payload: TenantCreate,
+    principal: Principal = Depends(current_principal),
+) -> dict[str, object]:
+    """Provision a tenant: create its schema and base tables.
+
+    Idempotent, so it is safe to call on every deployment.
+    """
+    try:
+        result = provision_tenant(_tenant_base_context(), payload.tenant)
+    except TenantError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    with connect(DEFAULT_PLATFORM_DB) as conn:
+        conn.execute(
+            "insert into audit_log (actor, action, target_type, target_id, detail) values (?, ?, ?, ?, ?)",
+            (
+                principal.actor,
+                "provision_tenant",
+                "tenant",
+                result["tenant"],
+                json.dumps({"schema": result["schema"]}, ensure_ascii=False),
+            ),
+        )
+    return result
+
+
+@app.get("/tenants/{tenant}/statistics")
+def tenant_stats(tenant: str) -> dict[str, object]:
+    """Row counts for one tenant, for verifying isolation after provisioning."""
+    try:
+        return tenant_statistics(tenant_context(_tenant_base_context(), tenant))
+    except TenantError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
 
 

--- a/backend/ontology_platform/context.py
+++ b/backend/ontology_platform/context.py
@@ -86,7 +86,9 @@ class PlatformContext:
                 if self._adapter is None:
                     from .database import _create_adapter
 
-                    self._adapter = _create_adapter(self.db_type, self.connection_uri)
+                    # Passing the schema is what activates per-tenant routing
+                    # (ADR-0006); an empty schema keeps the single-tenant path.
+                    self._adapter = _create_adapter(self.db_type, self.connection_uri, self.schema)
         return self._adapter
 
     def connect(self) -> Any:

--- a/backend/ontology_platform/database.py
+++ b/backend/ontology_platform/database.py
@@ -86,14 +86,20 @@ def _default_uri(db_type: str) -> str:
     return str(DEFAULT_PLATFORM_DB)
 
 
-def _create_adapter(db_type: str, connection_uri: str) -> PlatformAdapter:
+def _create_adapter(db_type: str, connection_uri: str, schema: str = "") -> PlatformAdapter:
+    """Build a platform adapter.
+
+    `schema` carries per-tenant routing (ADR-0006). SQLite ignores it: it has no
+    schema concept, so a tenant is a separate file and the routing already lives in
+    the connection URI.
+    """
     normalized = db_type.lower()
     if normalized == "sqlite":
         return SQLitePlatformAdapter(connection_uri)
     if normalized in ("postgresql", "postgres"):
-        return PostgreSQLPlatformAdapter(connection_uri)
+        return PostgreSQLPlatformAdapter(connection_uri, schema=schema)
     if normalized == "mysql":
-        return MySQLPlatformAdapter(connection_uri)
+        return MySQLPlatformAdapter(connection_uri, schema=schema)
     raise ValueError(f"不支持的平台数据库类型: {db_type}")
 
 
@@ -280,15 +286,27 @@ class SQLitePlatformAdapter:
 class PostgreSQLPlatformAdapter:
     db_type = "postgresql"
 
-    def __init__(self, connection_uri: str = ""):
+    def __init__(self, connection_uri: str = "", schema: str = ""):
         self.connection_uri = connection_uri or "postgresql://localhost:5432/ontology_platform"
+        # Set on every connection rather than baked into the URI, so one adapter
+        # cannot be pointed at another tenant's schema after the fact.
+        self.schema = schema
 
     def connect(self) -> Any:
         psycopg = importlib.import_module("psycopg")
         rows = importlib.import_module("psycopg.rows")
         # The whole platform accesses columns by name (row["id"]); psycopg
         # returns tuples unless a dict row factory is configured.
-        return psycopg.connect(self.connection_uri, connect_timeout=5, row_factory=rows.dict_row)
+        conn = psycopg.connect(self.connection_uri, connect_timeout=5, row_factory=rows.dict_row)
+        if self.schema:
+            # First isolation layer (ADR-0006): the tenant's rows are the only ones
+            # visible on this connection, so a query that forgets its tenant filter
+            # still cannot read across tenants. The identifier is validated by
+            # tenancy.schema_for() because search_path cannot take a bind parameter.
+            with conn.cursor() as cur:
+                cur.execute(f'set search_path to "{self.schema}", public')
+            conn.commit()
+        return conn
 
     def init_schema(self, conn: Any) -> None:
         # Postgres aborts the whole transaction on the first error, so each
@@ -316,8 +334,9 @@ class PostgreSQLPlatformAdapter:
 class MySQLPlatformAdapter:
     db_type = "mysql"
 
-    def __init__(self, connection_uri: str = ""):
+    def __init__(self, connection_uri: str = "", schema: str = ""):
         self.connection_uri = connection_uri or "mysql://root:password@localhost:3306/ontology_platform"
+        self.schema = schema
 
     def connect(self) -> Any:
         pymysql = importlib.import_module("pymysql")
@@ -325,6 +344,11 @@ class MySQLPlatformAdapter:
         options["connect_timeout"] = 5
         options["cursorclass"] = pymysql.cursors.DictCursor
         options["charset"] = "utf8mb4"
+        # MySQL's isolation unit is the database, so route by connecting to the
+        # tenant's database directly rather than issuing `use` afterwards -- that
+        # leaves no window where the connection points at the wrong place.
+        if self.schema:
+            options["database"] = self.schema
         return pymysql.connect(**options)
 
     def init_schema(self, conn: Any) -> None:

--- a/backend/ontology_platform/tenancy.py
+++ b/backend/ontology_platform/tenancy.py
@@ -1,0 +1,358 @@
+"""Multi-tenant isolation: separate schema plus a tenant_id column.
+
+Implements the model fixed in [ADR-0006](../../docs/adr/0006-tenant-isolation-model.md):
+a schema per tenant, **and** a `tenant_id` column on the tables that carry tenant
+data. The two layers exist because their failure modes do not overlap:
+
+- The **schema** stops a query that forgets its tenant filter -- the rows are simply
+  not visible on that connection.
+- The **tenant_id** turns a mis-routed connection into a visible error instead of a
+  silent cross-tenant read.
+
+Either layer alone is one mistake away from a leak. A shared-table design relies on
+every single query remembering `where tenant_id = ?`, and a missed filter is
+invisible in single-tenant test data -- which is exactly why that option was
+rejected.
+
+## Dialect differences
+
+| Dialect | Isolation unit | Applied by |
+|---|---|---|
+| PostgreSQL | schema | `set search_path` on connect |
+| MySQL | database | `use <db>` on connect |
+| SQLite | file | one file per tenant |
+
+SQLite has no schema concept, so a tenant maps to its own database file. That keeps
+the development experience identical while still being genuinely isolated.
+
+## Fail-closed
+
+`require_tenant()` raises when a tenant cannot be established. Defaulting to "all
+tenants" or "the first tenant" would turn a routing bug into a data leak, which is
+the same reasoning as ADR-0002: refuse rather than guess.
+
+Stability: experimental (ADR-0007).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from .context import DEFAULT_TENANT, PlatformContext, current_context
+from .database import connect, last_insert_id
+
+logger = logging.getLogger(__name__)
+
+# Tenant identifiers become schema and database names, so they are restricted to
+# what is safe as an SQL identifier. Validated rather than quoted because
+# `set search_path` and `use` cannot take a bind parameter -- the value has to be
+# interpolated, so it must be proven safe first.
+TENANT_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,38}$")
+
+SCHEMA_PREFIX = "tenant_"
+
+# Tables holding tenant-owned data. Reference and platform-global tables are
+# deliberately excluded: industry_blueprint is shared vocabulary, and
+# platform_user / user_session / model_config are platform-level concerns whose
+# rows are not tenant data.
+TENANT_SCOPED_TABLES: tuple[str, ...] = (
+    "data_source",
+    "ontology",
+    "business_object",
+    "business_rule",
+    "semantic_mapping",
+    "decision_record",
+    "inference_result",
+    "knowledge_document",
+    "knowledge_entry",
+    "conversation",
+    "audit_log",
+)
+
+
+class TenantError(ValueError):
+    """Raised when a tenant identifier is invalid or cannot be established."""
+
+
+def validate_tenant(tenant: str) -> str:
+    """Check a tenant identifier and return it normalised.
+
+    Strict because the value is interpolated into DDL and `set search_path`; an
+    unvalidated identifier there is an injection point that no amount of parameter
+    binding elsewhere would cover.
+    """
+    normalized = (tenant or "").strip().lower()
+    if not normalized:
+        raise TenantError("租户标识不能为空")
+    if not TENANT_PATTERN.match(normalized):
+        raise TenantError(f"租户标识不合法: {tenant!r}。只允许小写字母开头，字母、数字与下划线，最长 39 字符。")
+    return normalized
+
+
+def schema_for(tenant: str) -> str:
+    """The schema (PostgreSQL) or database (MySQL) name for a tenant.
+
+    Prefixed so a tenant cannot collide with a system schema such as `public` or
+    `information_schema`.
+    """
+    return f"{SCHEMA_PREFIX}{validate_tenant(tenant)}"
+
+
+def require_tenant(context: Optional[PlatformContext] = None) -> str:
+    """The tenant for this operation, or an error.
+
+    Fail-closed on purpose: falling back to "any tenant" would turn a routing bug
+    into a cross-tenant read, which is the failure this whole module exists to
+    prevent.
+    """
+    resolved = context if context is not None else current_context()
+    if resolved is None:
+        raise TenantError("未绑定平台上下文，无法确定租户")
+    return validate_tenant(resolved.tenant)
+
+
+def tenant_context(base: PlatformContext, tenant: str, *, sqlite_root: Optional[Path] = None) -> PlatformContext:
+    """Derive a context bound to one tenant.
+
+    For SQLite the connection URI is rewritten to a per-tenant file, because SQLite
+    has no schema to route to. For the server dialects the URI is unchanged and the
+    schema carries the isolation.
+    """
+    validated = validate_tenant(tenant)
+    schema = schema_for(validated)
+    if base.db_type == "sqlite":
+        current = Path(base.connection_uri)
+        root = sqlite_root or current.parent
+        target = root / f"{current.stem}-{validated}{current.suffix or '.sqlite3'}"
+        return PlatformContext(db_type="sqlite", connection_uri=str(target), tenant=validated, schema=schema)
+    return PlatformContext(
+        db_type=base.db_type,
+        connection_uri=base.connection_uri,
+        tenant=validated,
+        schema=schema,
+    )
+
+
+def provision_tenant(base: PlatformContext, tenant: str) -> dict[str, Any]:
+    """Create a tenant's schema and its base tables.
+
+    Idempotent: provisioning an existing tenant re-runs the schema creation, which
+    is what makes it safe to call on every deployment.
+    """
+    context = tenant_context(base, tenant)
+    if context.db_type in ("postgresql", "postgres"):
+        _create_postgres_schema(base, context.schema)
+    elif context.db_type == "mysql":
+        _create_mysql_database(base, context.schema)
+    context.initialize()
+    _ensure_tenant_columns(context)
+    return {
+        "tenant": context.tenant,
+        "schema": context.schema,
+        "dbType": context.db_type,
+        "connectionUri": context.describe()["connectionUri"],
+        "status": "provisioned",
+    }
+
+
+def _create_postgres_schema(base: PlatformContext, schema: str) -> None:
+    with base.connect() as conn:
+        with conn.cursor() as cur:
+            # Identifier already validated by schema_for(); it cannot be bound.
+            cur.execute(f'create schema if not exists "{schema}"')
+        conn.commit()
+
+
+def _create_mysql_database(base: PlatformContext, schema: str) -> None:
+    with base.connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"create database if not exists `{schema}` character set utf8mb4")
+        conn.commit()
+
+
+def _ensure_tenant_columns(context: PlatformContext) -> list[str]:
+    """Add the tenant_id column to tenant-scoped tables.
+
+    The second isolation layer. Existing rows are backfilled with the context's
+    tenant, so an upgrade of a single-tenant deployment lands in a consistent
+    state rather than with nulls that later queries would silently skip.
+    """
+    applied: list[str] = []
+    column_type = {
+        "sqlite": "text not null default ''",
+        "postgresql": "text not null default ''",
+        "postgres": "text not null default ''",
+        "mysql": "varchar(64) not null default ''",
+    }.get(context.db_type, "text not null default ''")
+
+    with context.connect() as conn:
+        for table in TENANT_SCOPED_TABLES:
+            if not _table_exists(conn, table, context.db_type):
+                continue
+            if _column_exists(conn, table, "tenant_id", context.db_type):
+                continue
+            try:
+                conn.execute(f"alter table {table} add column tenant_id {column_type}")
+                conn.execute(
+                    f"update {table} set tenant_id = ? where tenant_id = ''",
+                    (context.tenant,),
+                )
+                applied.append(table)
+            except Exception as error:
+                logger.warning("为表 %s 添加 tenant_id 失败: %s", table, error)
+    return applied
+
+
+def _table_exists(conn: Any, table: str, db_type: str) -> bool:
+    try:
+        if db_type == "sqlite":
+            row = conn.execute("select name from sqlite_master where type = 'table' and name = ?", (table,)).fetchone()
+            return row is not None
+        query = (
+            "select table_name from information_schema.tables where table_name = %s and table_schema = current_schema()"
+        )
+        if db_type == "mysql":
+            query = (
+                "select table_name from information_schema.tables where table_name = %s and table_schema = database()"
+            )
+        with conn.cursor() as cur:
+            cur.execute(query, (table,))
+            return cur.fetchone() is not None
+    except Exception as error:
+        logger.debug("检查表 %s 是否存在失败: %s", table, error)
+        return False
+
+
+def _column_exists(conn: Any, table: str, column: str, db_type: str) -> bool:
+    try:
+        if db_type == "sqlite":
+            rows = conn.execute(f"pragma table_info({table})").fetchall()
+            return any(row["name"] == column for row in rows)
+        query = (
+            "select column_name from information_schema.columns "
+            "where table_name = %s and column_name = %s and table_schema = current_schema()"
+        )
+        if db_type == "mysql":
+            query = (
+                "select column_name from information_schema.columns "
+                "where table_name = %s and column_name = %s and table_schema = database()"
+            )
+        with conn.cursor() as cur:
+            cur.execute(query, (table, column))
+            return cur.fetchone() is not None
+    except Exception as error:
+        logger.debug("检查列 %s.%s 失败: %s", table, column, error)
+        return False
+
+
+def list_tenants(base: PlatformContext) -> list[dict[str, Any]]:
+    """Discover provisioned tenants by inspecting schemas or files."""
+    prefix = SCHEMA_PREFIX
+    found: list[str] = []
+    try:
+        # PostgreSQL and MySQL both expose information_schema.schemata, so one
+        # branch serves both; only SQLite needs a different discovery mechanism.
+        if base.db_type in ("postgresql", "postgres", "mysql"):
+            with base.connect() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "select schema_name from information_schema.schemata where schema_name like %s",
+                    (f"{prefix}%",),
+                )
+                found = [_row_first(row) for row in cur.fetchall()]
+        else:
+            current = Path(base.connection_uri)
+            pattern = f"{current.stem}-*{current.suffix or '.sqlite3'}"
+            found = [f"{prefix}{path.stem[len(current.stem) + 1 :]}" for path in sorted(current.parent.glob(pattern))]
+    except Exception as error:
+        logger.warning("枚举租户失败: %s", error)
+        return []
+    return [{"tenant": name[len(prefix) :], "schema": name} for name in sorted(set(found)) if name.startswith(prefix)]
+
+
+def _row_first(row: Any) -> str:
+    if isinstance(row, dict):
+        return str(next(iter(row.values())))
+    return str(row[0])
+
+
+def scope_query(
+    query: str, params: Iterable[Any], table_alias: str = "", *, tenant: str = ""
+) -> tuple[str, tuple[Any, ...]]:
+    """Append a tenant predicate to a query.
+
+    Provided for callers that read tenant-scoped tables directly. The schema
+    already isolates them; this adds the second layer, so a mis-routed connection
+    returns nothing instead of another tenant's rows.
+    """
+    resolved = validate_tenant(tenant or require_tenant())
+    column = f"{table_alias}.tenant_id" if table_alias else "tenant_id"
+    separator = " and " if re.search(r"\bwhere\b", query, re.IGNORECASE) else " where "
+    return f"{query}{separator}({column} = ? or {column} = '')", (*tuple(params), resolved)
+
+
+def assert_tenant_row(row: Any, *, tenant: str = "") -> None:
+    """Verify a fetched row belongs to the expected tenant.
+
+    The second layer's detection half. If schema routing ever sends a connection to
+    the wrong place, this converts a silent cross-tenant read into an exception at
+    the point of use.
+    """
+    if row is None:
+        return
+    expected = validate_tenant(tenant or require_tenant())
+    try:
+        actual = row["tenant_id"]
+    except (KeyError, IndexError, TypeError):
+        return
+    # An empty value means the row predates tenancy, which is legitimate in an
+    # upgraded single-tenant deployment.
+    if actual and str(actual) != expected:
+        raise TenantError(f"检测到跨租户数据访问：期望 {expected}，实际 {actual}。已阻止该操作。")
+
+
+def stamp_tenant(values: dict[str, Any], *, tenant: str = "") -> dict[str, Any]:
+    """Add the tenant to a row about to be written."""
+    resolved = validate_tenant(tenant or require_tenant())
+    return {**values, "tenant_id": resolved}
+
+
+def tenant_statistics(context: PlatformContext) -> dict[str, Any]:
+    """Row counts per tenant-scoped table, for verifying isolation."""
+    counts: dict[str, int] = {}
+    with context.connect() as conn:
+        for table in TENANT_SCOPED_TABLES:
+            if not _table_exists(conn, table, context.db_type):
+                continue
+            try:
+                row = conn.execute(f"select count(*) as c from {table}").fetchone()
+                counts[table] = int(row["c"] if row else 0)
+            except Exception as error:
+                logger.debug("统计表 %s 失败: %s", table, error)
+    return {
+        "tenant": context.tenant,
+        "schema": context.schema,
+        "tables": counts,
+        "totalRows": sum(counts.values()),
+    }
+
+
+__all__ = [
+    "DEFAULT_TENANT",
+    "TENANT_SCOPED_TABLES",
+    "TenantError",
+    "assert_tenant_row",
+    "connect",
+    "last_insert_id",
+    "list_tenants",
+    "provision_tenant",
+    "require_tenant",
+    "schema_for",
+    "scope_query",
+    "stamp_tenant",
+    "tenant_context",
+    "tenant_statistics",
+    "validate_tenant",
+]

--- a/docs/architecture-debt.md
+++ b/docs/architecture-debt.md
@@ -137,6 +137,8 @@ SQLite 的 `text`）只会在对应后端上暴露。
   → 运行时注册表 + entry points（`registry.py`，ADR-0007）
 - ~~复合主键三处 `raise ValueError`，连接表与版本化表无法建模~~
   → 实例键抽象（`instance_key.py`，ADR-0008）
+- ~~多租户未实现，31 张表零租户概念~~
+  → 独立 schema + `tenant_id` 双保险（`tenancy.py`，ADR-0006），三方言实测隔离
 - ~~会话不落库、无反馈闭环，答案对错无法追溯~~
   → `conversations.py`：会话持久化 + 反馈锚定决策记录 + 转人工
 - ~~`guard_expression` / `filter_expression` / `depends_on` 有存储但从不求值~~

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -181,6 +181,26 @@ register_embedding_model("bge-m3", lambda text: my_model.encode(text).tolist())
 
 查询已注册项：`supported_retrieval_backends()`、`supported_embedding_models()`
 
+## 6. 多租户上下文
+
+扩展若要访问平台数据，应通过上下文而非硬编码路径，否则在多租户部署下会读到
+错误的租户数据。
+
+```python
+from ontology_platform.context import use_context
+from ontology_platform.tenancy import tenant_context, require_tenant, scope_query
+
+ctx = tenant_context(base_context, "acme")
+with use_context(ctx):
+    tenant = require_tenant()          # 无法确定租户时抛错，而非猜测
+    query, params = scope_query("select * from data_source", ())
+    with ctx.connect() as conn:
+        rows = conn.execute(query, params).fetchall()
+```
+
+**要点：** `require_tenant()` 是 fail-closed 的。若你的扩展在无上下文时也要能跑，
+请显式处理 `TenantError`，不要退化为「读所有租户」。
+
 ## 尚未开放的扩展点
 
 以下在 [ROADMAP](../ROADMAP.md) 中，目前**没有**扩展机制：

--- a/tests/test_multi_tenancy.py
+++ b/tests/test_multi_tenancy.py
@@ -1,0 +1,367 @@
+"""Multi-tenant isolation: separate schema plus a tenant_id column.
+
+Implements ADR-0006. The two layers exist because their failure modes do not
+overlap: the schema stops a query that forgets its tenant filter, and tenant_id
+turns a mis-routed connection into a visible error rather than a silent
+cross-tenant read.
+
+That second property is the reason the shared-table design was rejected: a missed
+`where tenant_id = ?` is invisible in single-tenant test data. So these tests
+assert isolation *positively* -- tenant A cannot see tenant B's rows -- rather than
+only checking that a filter string was appended.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from ontology_platform import database as database_module
+from ontology_platform.context import PlatformContext, reset_default_context, use_context
+from ontology_platform.metadata import list_data_sources, register_data_source
+from ontology_platform.tenancy import (
+    SCHEMA_PREFIX,
+    TENANT_SCOPED_TABLES,
+    TenantError,
+    assert_tenant_row,
+    list_tenants,
+    provision_tenant,
+    require_tenant,
+    schema_for,
+    scope_query,
+    stamp_tenant,
+    tenant_context,
+    tenant_statistics,
+    validate_tenant,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_default():
+    reset_default_context()
+    saved = database_module._platform_adapter
+    database_module._platform_adapter = None
+    yield
+    reset_default_context()
+    database_module._platform_adapter = saved
+
+
+@pytest.fixture
+def base(tmp_path: Path) -> PlatformContext:
+    return PlatformContext(db_type="sqlite", connection_uri=str(tmp_path / "platform.sqlite3"))
+
+
+def _business_db(path: Path) -> str:
+    sqlite3.connect(path).close()
+    return str(path)
+
+
+# -- Identifier validation: this is an injection boundary --
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "acme; drop table data_source",
+        'public"',
+        "tenant'--",
+        "1abc",
+        "",
+        "   ",
+        "a" * 40,
+        "has space",
+        "has-dash",
+    ],
+)
+def test_unsafe_tenant_identifiers_are_rejected(value) -> None:
+    """Tenant names are interpolated into DDL and search_path, which cannot bind."""
+    with pytest.raises(TenantError):
+        validate_tenant(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("acme", "acme"), ("ACME", "acme"), ("  acme  ", "acme"), ("a_1", "a_1")],
+)
+def test_valid_identifiers_are_normalised(value, expected) -> None:
+    assert validate_tenant(value) == expected
+
+
+def test_schema_name_is_prefixed_to_avoid_system_collisions() -> None:
+    """Without a prefix a tenant could be named `public` or `information_schema`."""
+    assert schema_for("acme") == f"{SCHEMA_PREFIX}acme"
+    assert schema_for("public") == f"{SCHEMA_PREFIX}public"
+
+
+# -- Fail-closed --
+
+
+def test_require_tenant_refuses_when_no_context_is_bound() -> None:
+    """Defaulting to "any tenant" would turn a routing bug into a data leak."""
+    with pytest.raises(TenantError, match="未绑定平台上下文"):
+        require_tenant()
+
+
+def test_require_tenant_reads_the_bound_context(base: PlatformContext) -> None:
+    with use_context(tenant_context(base, "acme")):
+        assert require_tenant() == "acme"
+
+
+# -- Layer one: schema / file isolation --
+
+
+def test_sqlite_maps_each_tenant_to_its_own_file(base: PlatformContext) -> None:
+    """SQLite has no schema concept, so the file is the isolation unit."""
+    first = tenant_context(base, "acme")
+    second = tenant_context(base, "globex")
+    assert first.connection_uri != second.connection_uri
+    assert first.connection_uri.endswith("platform-acme.sqlite3")
+    assert second.connection_uri.endswith("platform-globex.sqlite3")
+
+
+def test_provisioning_is_idempotent(base: PlatformContext) -> None:
+    """Safe to call on every deployment."""
+    first = provision_tenant(base, "acme")
+    second = provision_tenant(base, "acme")
+    assert first["schema"] == second["schema"] == f"{SCHEMA_PREFIX}acme"
+
+
+def test_one_tenant_cannot_see_another_tenants_rows(base: PlatformContext, tmp_path: Path) -> None:
+    """The property that matters. Asserted positively, not via filter strings."""
+    provision_tenant(base, "acme")
+    provision_tenant(base, "globex")
+
+    register_data_source(
+        tenant_context(base, "acme"),
+        "ACME 的数据源",
+        "sqlite",
+        _business_db(tmp_path / "a.sqlite3"),
+        domain="测试",
+    )
+    register_data_source(
+        tenant_context(base, "globex"),
+        "GLOBEX 的数据源",
+        "sqlite",
+        _business_db(tmp_path / "b.sqlite3"),
+        domain="测试",
+    )
+
+    acme_names = [item["name"] for item in list_data_sources(tenant_context(base, "acme"))]
+    globex_names = [item["name"] for item in list_data_sources(tenant_context(base, "globex"))]
+
+    assert acme_names == ["ACME 的数据源"]
+    assert globex_names == ["GLOBEX 的数据源"]
+
+
+def test_a_tenant_starts_empty_even_when_another_has_data(base: PlatformContext, tmp_path: Path) -> None:
+    provision_tenant(base, "acme")
+    register_data_source(
+        tenant_context(base, "acme"),
+        "只属于 ACME",
+        "sqlite",
+        _business_db(tmp_path / "a.sqlite3"),
+        domain="测试",
+    )
+    provision_tenant(base, "newcomer")
+    assert list_data_sources(tenant_context(base, "newcomer")) == []
+
+
+def test_tenants_can_be_discovered(base: PlatformContext) -> None:
+    provision_tenant(base, "acme")
+    provision_tenant(base, "globex")
+    assert {item["tenant"] for item in list_tenants(base)} == {"acme", "globex"}
+
+
+def test_statistics_report_per_tenant_counts(base: PlatformContext, tmp_path: Path) -> None:
+    provision_tenant(base, "acme")
+    provision_tenant(base, "globex")
+    register_data_source(
+        tenant_context(base, "acme"),
+        "源",
+        "sqlite",
+        _business_db(tmp_path / "a.sqlite3"),
+        domain="测试",
+    )
+    assert tenant_statistics(tenant_context(base, "acme"))["tables"]["data_source"] == 1
+    assert tenant_statistics(tenant_context(base, "globex"))["tables"]["data_source"] == 0
+
+
+def test_derived_context_carries_the_schema(base: PlatformContext) -> None:
+    assert tenant_context(base, "acme").schema == f"{SCHEMA_PREFIX}acme"
+
+
+def test_server_dialects_keep_the_uri_and_route_by_schema() -> None:
+    """For PostgreSQL and MySQL the URI is unchanged; the schema isolates."""
+    base = PlatformContext(db_type="postgresql", connection_uri="postgresql://localhost:5432/platform")
+    derived = tenant_context(base, "acme")
+    assert derived.connection_uri == base.connection_uri
+    assert derived.schema == f"{SCHEMA_PREFIX}acme"
+
+
+def test_postgres_adapter_receives_the_schema() -> None:
+    """Routing must reach the adapter, not merely sit on the context."""
+    context = PlatformContext(
+        db_type="postgresql",
+        connection_uri="postgresql://localhost:5432/platform",
+        schema="tenant_acme",
+    )
+    assert context.adapter.schema == "tenant_acme"
+
+
+def test_mysql_adapter_receives_the_schema() -> None:
+    context = PlatformContext(
+        db_type="mysql",
+        connection_uri="mysql://root@localhost:3306/platform",
+        schema="tenant_acme",
+    )
+    assert context.adapter.schema == "tenant_acme"
+
+
+def test_single_tenant_context_has_no_schema_routing(base: PlatformContext) -> None:
+    """Existing single-tenant deployments must be unaffected."""
+    assert base.schema == ""
+
+
+# -- Layer two: tenant_id --
+
+
+def test_tenant_id_column_is_added_to_scoped_tables(base: PlatformContext) -> None:
+    provision_tenant(base, "acme")
+    context = tenant_context(base, "acme")
+    with context.connect() as conn:
+        columns = {row["name"] for row in conn.execute("pragma table_info(data_source)").fetchall()}
+    assert "tenant_id" in columns
+
+
+def test_platform_global_tables_are_not_tenant_scoped() -> None:
+    """Blueprints are shared vocabulary; users and model config are platform-level."""
+    for table in ("industry_blueprint", "platform_user", "user_session", "model_config"):
+        assert table not in TENANT_SCOPED_TABLES
+
+
+def test_stamp_tenant_adds_the_owner_to_a_write(base: PlatformContext) -> None:
+    with use_context(tenant_context(base, "acme")):
+        assert stamp_tenant({"name": "x"})["tenant_id"] == "acme"
+
+
+def test_cross_tenant_row_is_detected(base: PlatformContext) -> None:
+    """If schema routing ever misfires, this converts a silent read into an error."""
+    with use_context(tenant_context(base, "acme")):
+        with pytest.raises(TenantError, match="跨租户"):
+            assert_tenant_row({"tenant_id": "globex"})
+
+
+def test_same_tenant_row_passes(base: PlatformContext) -> None:
+    with use_context(tenant_context(base, "acme")):
+        assert_tenant_row({"tenant_id": "acme"})
+
+
+def test_legacy_rows_without_a_tenant_are_accepted(base: PlatformContext) -> None:
+    """An upgraded single-tenant deployment has rows that predate tenancy."""
+    with use_context(tenant_context(base, "acme")):
+        assert_tenant_row({"tenant_id": ""})
+
+
+@pytest.mark.parametrize("row", [None, {"id": 1}])
+def test_rows_without_the_column_are_accepted(base: PlatformContext, row) -> None:
+    with use_context(tenant_context(base, "acme")):
+        assert_tenant_row(row)
+
+
+def test_scope_query_appends_a_where_clause(base: PlatformContext) -> None:
+    with use_context(tenant_context(base, "acme")):
+        query, params = scope_query("select * from data_source", ())
+    assert "where" in query
+    assert params == ("acme",)
+
+
+def test_scope_query_appends_and_when_a_where_exists(base: PlatformContext) -> None:
+    with use_context(tenant_context(base, "acme")):
+        query, params = scope_query("select * from ontology where status = ?", ("draft",), "o")
+    assert " and " in query
+    assert "o.tenant_id" in query
+    assert params == ("draft", "acme")
+
+
+def test_scope_query_tolerates_legacy_rows(base: PlatformContext) -> None:
+    """Must not hide rows written before the column existed."""
+    with use_context(tenant_context(base, "acme")):
+        query, _ = scope_query("select * from data_source", ())
+    assert "= ''" in query
+
+
+# -- Server dialects, when available --
+
+
+def _server_context(env_var: str, db_type: str, database: str) -> PlatformContext | None:
+    uri = os.environ.get(env_var, "")
+    if not uri:
+        return None
+    return PlatformContext(db_type=db_type, connection_uri=f"{uri}{database}")
+
+
+@pytest.mark.parametrize(
+    ("env_var", "db_type", "database"),
+    [
+        ("ONTOLOGY_TEST_POSTGRES_URI", "postgresql", "postgres"),
+        ("ONTOLOGY_TEST_MYSQL_URI", "mysql", "mysql"),
+    ],
+)
+def test_isolation_holds_on_server_dialects(env_var, db_type, database, tmp_path: Path) -> None:
+    """Skips when no server is reachable, matching the dialect test convention."""
+    base = _server_context(env_var, db_type, database)
+    if base is None:
+        pytest.skip(f"{env_var} 未设置")
+    try:
+        base.connect().close()
+    except Exception as error:  # pragma: no cover - environment dependent
+        pytest.skip(f"{db_type} 不可用: {error}")
+
+    provision_tenant(base, "isolation_a")
+    provision_tenant(base, "isolation_b")
+
+    register_data_source(
+        tenant_context(base, "isolation_a"),
+        "A 源",
+        "sqlite",
+        _business_db(tmp_path / "a.sqlite3"),
+        domain="测试",
+    )
+    register_data_source(
+        tenant_context(base, "isolation_b"),
+        "B 源",
+        "sqlite",
+        _business_db(tmp_path / "b.sqlite3"),
+        domain="测试",
+    )
+
+    a_names = [item["name"] for item in list_data_sources(tenant_context(base, "isolation_a"))]
+    b_names = [item["name"] for item in list_data_sources(tenant_context(base, "isolation_b"))]
+    assert "A 源" in a_names and "B 源" not in a_names, a_names
+    assert "B 源" in b_names and "A 源" not in b_names, b_names
+
+
+# -- API surface --
+
+
+def test_tenant_endpoints_have_sensible_capabilities() -> None:
+    """Provisioning creates schemas and tables, so it is strictly administrative."""
+    from ontology_platform.access_policy import required_capability
+
+    assert required_capability("POST", "/tenants") == "platform:admin"
+    assert required_capability("GET", "/tenants") == "platform:read"
+    assert required_capability("GET", "/tenants/acme/statistics") == "platform:read"
+
+
+def test_listing_tenants_on_a_single_tenant_deployment_is_not_an_error(
+    base: PlatformContext,
+) -> None:
+    """Multi-tenancy is opt-in; provisioning nothing must return an empty list."""
+    assert list_tenants(base) == []


### PR DESCRIPTION
## 改动内容

落地 ADR-0006 定下的隔离模型。ADR-0010 移除全局单例后,这项的硬前置才解除。

**双层隔离,因为两层的失效模式不重叠:**

| 层 | 作用 |
|---|---|
| **schema** | 挡住忘写租户过滤的查询——那些行在这条连接上根本不可见 |
| **`tenant_id`** | 把路由错误变成**可见报错**,而非静默跨租户读取 |

任何单层都离泄漏只差一个失误。共享表方案被否决的原因很具体:它把正确性押在「每条查询都记得加 `where tenant_id = ?`」上,而**漏写过滤在单租户测试数据下完全看不出来**。

## 方言路由

在 connect 时施加,而非烧进 URI——这样适配器事后无法被重新指向别的租户:

- **PostgreSQL**: `set search_path to "tenant_x", public`
- **MySQL**: 直接连到租户 database,**不留「连接指向错误位置」的时间窗**
- **SQLite**: 一租户一文件(它没有 schema 概念)

## 安全相关细节

- 租户标识严格校验 `^[a-z][a-z0-9_]{0,38}$`——它会被插入 DDL 与 `search_path`,**这两处都无法用绑定参数**,所以必须先证明安全。已验证 `acme; drop table data_source`、`public"` 被拒
- schema 名带前缀,租户无法与 `public`／`information_schema` 撞名
- `require_tenant()` 在无法确定租户时**抛错而非猜测**——退化为「读所有租户」会把路由 bug 变成数据泄漏,与 ADR-0002 同一立场
- `tenant_id` 为空的行被接受:升级后的单租户部署合法地存在早于租户功能的行,`_ensure_tenant_columns` 会回填而非留 null(留 null 会被过滤静默跳过)

## 验证方式(在真实服务端,不只 SQLite)

- [x] **411 tests passed**(新增 42)
- [x] ruff / mypy clean
- [x] **PostgreSQL**: `show search_path` 返回 `tenant_acme, public`,各租户只看到自己的行
- [x] **MySQL**: `select database()` 返回 `tenant_acme`,`tenant_id` 列存在
- [x] **三方言均实测**「A 租户看不到 B 租户数据」——正面断言隔离,不是只检查过滤字符串是否拼上
- [x] **干净 clone + 全新 venv**(带 MySQL/PG 环境变量):411 通过,服务端隔离测试真实执行而非跳过
- [x] 租户 API 实测:开通幂等、非法标识返回 400、单租户部署返回空列表而非报错

## 破坏性变更

无。多租户**可选**:未调用 `provision_tenant()` 的部署行为完全不变。

## SECURITY.md 写明了实话

没有暗示「已获得全面保护」,而是明确:租户是可选的;从未开通租户的部署仍是单租户模式;**自定义代码若直接用 `connect()` 而不绑定租户上下文,不会自动获得隔离**。

## 仍未完成

检索期权限过滤、租户级配额尚未实现,ROADMAP 已如实标注。