### PR TITLE
守住 README 规模数字：它已漂出一半以上

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -657,7 +657,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**1166 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
+**1167 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
 no server is reachable.
 
 | File | Count | Covers |

--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**1166 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
+**1167 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
 对应用例自动跳过。分布：
 
 | 文件 | 数量 | 覆盖 |
@@ -949,7 +949,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_standard_vocabulary.py` | 24 | OWL/RDFS 映射、SHACL 形状生成、IRI 稳定性、导出必须能被 RDF 解析器解析 |
 | `test_axioms.py` | 20 | 公理五类校验、声明期拒绝、发布门禁阻断、缺表读作未配置 |
 | `test_module_boundaries.py` | 6 | 无循环依赖、无跨模块私有引用、`__all__` 可解析 |
-| `test_documented_claims.py` | 5 | README 声明的测试数、分布表、端点数、Python 版本、技术债计数与代码一致 |
+| `test_documented_claims.py` | 6 | README 声明的测试数、分布表、端点数、Python 版本、技术债计数与代码一致 |
 | `test_metadata_flow.py` | 34 | 接入、扫描、本体生成、接入准备度 |
 | `test_api_authentication.py` | 28 | 认证、会话、能力策略、actor 可信 |
 | `test_domain_neutrality.py` | 25 | 未知领域全链路 + 静态守卫 |
@@ -972,7 +972,7 @@ CI 另有一个 `quickstart` job，在干净环境重跑本 README 的快速开�
 
 ## 规模
 
-29 个后端模块约 13400 行，98 个 API 端点，31 张平台表，前端 React + antd。
+71 个后端模块约 31400 行，149 个 API 端点，44 张平台表，前端 React + antd。
 
 ## 示例
 

--- a/tests/test_documented_claims.py
+++ b/tests/test_documented_claims.py
@@ -168,3 +168,69 @@ def test_the_documented_signature_migration_count_is_current() -> None:
         claimed = {int(found) for found in regex.findall(r"(\d+) 处 `platform_db", text)}
         assert claimed, f"{filename} 未声明待迁移签名数量"
         assert actual in claimed, f"{filename} 声明 {sorted(claimed)} 处，实际 {actual} 处"
+
+
+def test_the_documented_scale_is_current() -> None:
+    """The "规模" line is the first thing a reader checks against reality.
+
+    It had drifted badly -- 29 modules and 98 endpoints against an actual 71 and 149 --
+    which is the kind of error that costs more than it looks: a reader who verifies one
+    headline number and finds it less than half right stops trusting every other number in
+    the document, including the ones that are correct.
+
+    Counted with tolerance rather than exactly for the line total, since prose cannot
+    reasonably track single-line edits. Module and endpoint counts are exact: those change
+    only when something is added or removed.
+    """
+    import re as regex
+
+    package = ROOT / "backend" / "ontology_platform"
+    modules = sorted(path for path in package.rglob("*.py") if "__pycache__" not in str(path))
+    lines = sum(len(path.read_text(encoding="utf-8").splitlines()) for path in modules)
+
+    import sys
+
+    sys.path.insert(0, str(ROOT / "backend"))
+    from ontology_platform.api import declared_routes
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    claim = regex.search(r"(\d+) 个后端模块约 (\d+) 行，(\d+) 个 API 端点，(\d+) 张平台表", readme)
+    assert claim, "README 规模一节格式已变，请同步本测试"
+    stated_modules, stated_lines, stated_endpoints, stated_tables = (int(value) for value in claim.groups())
+
+    assert stated_modules == len(modules), f"声明 {stated_modules} 个模块，实际 {len(modules)}"
+    assert stated_endpoints == len(declared_routes()), f"声明 {stated_endpoints} 个端点，实际 {len(declared_routes())}"
+    # Within 5%: close enough to be honest, loose enough not to fail on a comment edit.
+    assert abs(stated_lines - lines) / lines < 0.05, f"声明约 {stated_lines} 行，实际 {lines}"
+
+    tables = _platform_table_count()
+    assert stated_tables == tables, f"声明 {stated_tables} 张平台表，实际 {tables}"
+
+
+def _platform_table_count() -> int:
+    """Tables a freshly initialised platform database contains.
+
+    Counted by running `aletheia init` rather than by grepping DDL: feature modules own
+    their own `SchemaBundle`, so a grep of `database.py` would miss every table added since
+    the metamodel grew -- which is most of them. Driving the CLI also means the count is
+    what a user actually gets, not what the internals could produce.
+    """
+    import contextlib
+    import io
+    import sqlite3
+    import sys
+    import tempfile
+    from pathlib import Path as FsPath
+
+    sys.path.insert(0, str(ROOT / "backend"))
+    from ontology_platform.cli import main
+
+    database = FsPath(tempfile.mkdtemp()) / "scale.sqlite3"
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert main(["--platform-db", str(database), "init"]) == 0
+    with sqlite3.connect(database) as raw:
+        return int(
+            raw.execute(
+                "select count(*) from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+            ).fetchone()[0]
+        )


### PR DESCRIPTION
## 问题

README「规模」一节写着 **29 个后端模块、98 个 API 端点**。实际是 **71 个和 149 个**。

这类过期声明的代价比看起来大：它是读者拿来跟现实核对的第一个数字，而一个对不上一半的头条数字会教会他**不再相信文档里其余任何数字**——包括那些正确的，也包括「当前限制」一节，而那一节恰恰是最需要被相信的部分。

## 修法

与测试数、端点数一样纳入断言：

| 项 | 精度 | 理由 |
|---|---|---|
| 模块数、端点数 | 精确 | 只有增删才会变 |
| 代码行数 | ±5% | 散文没法跟踪单行改动，而一个会因改注释失败的检查会被删掉 |
| 平台表数 | 精确 | 由 `aletheia init` 实跑得出 |

表数**不用 grep DDL**：各特性模块自持 `SchemaBundle`，grep `database.py` 会漏掉元模型扩张以来新增的大部分表。跑 CLI 也意味着这个数字是**用户真正拿到的**，而不是内部可能产出的。

同时修正为 71 个模块约 31400 行、149 个端点、44 张平台表。

## 验证

1165 通过、2 按环境跳过，ruff 与 mypy 干净。