### PR TITLE
补齐版本化迁移，并纠正 Alembic 的阻塞理由

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -657,7 +657,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**1167 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
+**1179 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
 no server is reachable.
 
 | File | Count | Covers |

--- a/README.md
+++ b/README.md
@@ -667,8 +667,10 @@ _不是_：算法、模型、策略引擎脚本。
   生成器只会产出 `unknown`。**请求侧的一致性已由测试守住**——
   该测试发现了一处真实缺陷：前端一直在发送 4 个模型兼容性字段，
   而 API 请求模型未声明它们，Pydantic 静默丢弃，于是 Azure 与本地 vLLM 配不上而界面报成功。
-- DDL 调度已统一到 `schema.py`，但**尚未迁移 Alembic**——迁移需归属于某个分发包，
-  因此阻塞于分包边界。
+- **版本化迁移已具备**（`migrations.py`）：账本记录已应用版本，改列／回填／删表这类
+  非幂等变更现在有处可去。**不采用 Alembic**——它依赖 SQLAlchemy，与内核零依赖冲突；
+  而它真正提供的（版本账本 + 有序应用）只需 150 行，且自动生成在此不可用
+  （DDL 是按方言声明的字符串，无模型元数据可 diff）。
 - **尚未拆分为多个 PyPI 分发包**。当前是单包 `aletheia-onto` + optional extras，
   extras 承载了未来分包的接缝但不冻结边界。
 
@@ -910,7 +912,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**1167 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
+**1179 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
 对应用例自动跳过。分布：
 
 | 文件 | 数量 | 覆盖 |
@@ -924,6 +926,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_inert_fields_activated.py` | 28 | 守卫、行级过滤、规则依赖、策略本体维度 |
 | `test_conversations_and_feedback.py` | 35 | 会话持久化、反馈归因、转人工 |
 | `test_platform_context.py` | 23 | 多实例隔离、线程绑定、向后兼容 |
+| `test_migrations.py` | 12 | 旧库补齐、新装跳过、重跑无变更、失败即中止后续 |
 | `test_sso.py` | 32 | 签名伪造、alg:none 绕过、未映射即拒绝、禁用本地账号优先 |
 | `test_frontend_type_agreement.py` | 12 | 前后端请求字段一致（漂移会静默丢弃用户输入） |
 | `test_audit_reports.py` | 18 | 从未触发的规则、覆盖门禁的发布、留痕完整性、区间半开 |
@@ -972,7 +975,7 @@ CI 另有一个 `quickstart` job，在干净环境重跑本 README 的快速开�
 
 ## 规模
 
-71 个后端模块约 31400 行，149 个 API 端点，44 张平台表，前端 React + antd。
+73 个后端模块约 31800 行，149 个 API 端点，45 张平台表，前端 React + antd。
 
 ## 示例
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,20 @@ Dify 的同类产品，失去差异化。
 两项不变量由 `tests/test_module_boundaries.py` 守住——
 只靠文档记录的约束会一次一个「顺手的延迟 import」地退化。
 
-🚧 仍待完成：192 处 `platform_db` 签名迁移、DDL 迁 Alembic（依赖分包边界）。
+✅ **版本化迁移已完成**（`migrations.py`）。原记为「DDL 迁 Alembic，阻塞于分包边界」——
+那个理由不完整。真正的阻塞更基本：**Alembic 依赖 SQLAlchemy**，与内核零依赖直接冲突
+（`pyproject` 声明、CI 在裸装环境校验）。采用它意味着本体、规则引擎与决策留痕
+再也无法嵌入别人的应用而不拖进一个 ORM。
+
+Alembic 真正提供而本项目缺的只有两点：版本账本与有序应用。自动生成在此不可用——
+DDL 是按方言声明的字符串，没有模型元数据可以 diff。因此这不是等待 Alembic 的权宜之计，
+而是按问题本身的规模给出的机制：150 行、零依赖、覆盖同样三个方言。
+
+引导序列也合并为一处（`bootstrap.py`）：此前 HTTP 启动与 CLI `init` 各枚举一遍特性表，
+而漏掉一个不会响亮地失败——它产生的库会让某个功能返回空结果而非报错，
+而「知识库里没有条目」在很长时间里都会被当成数据问题。
+
+🚧 仍待完成：192 处 `platform_db` 签名迁移。
 
 逐项工作清单见 [docs/architecture-debt.md](docs/architecture-debt.md)。
 

--- a/backend/ontology_platform/api.py
+++ b/backend/ontology_platform/api.py
@@ -18,34 +18,21 @@ from .access_policy import (
     required_capability,
 )
 from .agent import agent_chat, get_agent_roles
-from .agent_roles import delete_agent_role, init_agent_role_schema, upsert_agent_role
-from .aggregation import (
-    init_aggregate_schema,
-)
+from .agent_roles import delete_agent_role, upsert_agent_role
 from .auth import (
     AuthenticationError,
     AuthorizationError,
     Principal,
     authorize,
     ensure_bootstrap_admin,
-    init_auth_schema,
     purge_expired_sessions,
     resolve_principal,
 )
 from .automation import execute_operation, preflight_operation
-from .axioms import init_axiom_schema
+from .bootstrap import prepare_database
 from .contract_documents import parse_rule_docx_bytes
-from .conversations import (
-    init_conversation_schema,
-)
 from .credentials import redact_connection_uri
 from .database import DEFAULT_PLATFORM_DB, configure_platform_db, connect, get_platform_config, initialize_platform_db
-from .entity_resolution import (
-    init_entity_resolution_schema,
-)
-from .events import (
-    init_event_schema,
-)
 from .governance import (
     bulk_review_semantic_mappings,
     delete_business_rule,
@@ -62,9 +49,6 @@ from .governance import (
 from .graph_view import build_ontology_graph
 from .http_runtime import AUTH_ENABLED, DEV_ADMIN_PRINCIPAL, bearer_token, current_principal
 from .industry_blueprints import list_industry_blueprints, upsert_industry_blueprint
-from .knowledge_documents import (
-    init_knowledge_schema,
-)
 from .metadata import (
     register_data_source,
     register_source_api,
@@ -79,7 +63,6 @@ from .ontology import (
     resolve_ontology_for_object,
     summarize_ontology,
 )
-from .quotas import init_quota_schema
 from .release_readiness import assess_ontology_release_readiness
 from .routers import (
     auth_router,
@@ -102,16 +85,13 @@ from .semantic_kernel import (
     available_rule_names,
     validate_rule_expression,
 )
-from .sso import init_sso_schema
 from .standard_vocabulary import STANDARD_EXPORT_FORMATS, export_standard_asset
 from .temporal import (
     TemporalError,
-    init_temporal_schema,
 )
 from .vocabulary import default_object_code_for_ontology
 from .workbench import build_workbench
 from .workflow_permission import (
-    init_workflow_and_permission_schema,
     seed_default_roles_and_policies,
     seed_default_tools,
 )
@@ -129,18 +109,12 @@ async def lifespan(app: FastAPI):
     # Schema creation must not be silently swallowed: a missing table turns
     # into a confusing 500 on first use instead of a clear startup failure.
     with connect(DEFAULT_PLATFORM_DB) as conn:
-        init_workflow_and_permission_schema(conn)
-        init_auth_schema(conn)
-        init_agent_role_schema(conn)
-        init_knowledge_schema(conn)
-        init_aggregate_schema(conn)
-        init_event_schema(conn)
-        init_temporal_schema(conn)
-        init_entity_resolution_schema(conn)
-        init_conversation_schema(conn)
-        init_axiom_schema(conn)
-        init_quota_schema(conn)
-        init_sso_schema(conn)
+        # One list, shared with the CLI. Two lists is what this used to be, and a schema
+        # missing from one produces a database where a feature returns empty results
+        # rather than an error.
+        for entry in prepare_database(conn):
+            if entry["status"] == "applied":
+                logger.info("已应用迁移 %s: %s", entry["version"], entry.get("description", ""))
     seed_default_tools(DEFAULT_PLATFORM_DB)
     seed_default_roles_and_policies(DEFAULT_PLATFORM_DB)
     if AUTH_ENABLED:

--- a/backend/ontology_platform/auth.py
+++ b/backend/ontology_platform/auth.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from .database import connect
-from .schema import SchemaBundle
+from .schema import ColumnAddition, SchemaBundle
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,7 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             password_hash text not null,
             password_salt text not null,
             iterations integer not null default 240000,
+            identity_source text not null default 'local',
             status text not null default 'active',
             created_at text not null default current_timestamp,
             updated_at text not null default current_timestamp,
@@ -86,6 +87,7 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             password_hash text not null,
             password_salt text not null,
             iterations integer not null default 240000,
+            identity_source text not null default 'local',
             status text not null default 'active',
             created_at timestamp not null default current_timestamp,
             updated_at timestamp not null default current_timestamp,
@@ -100,6 +102,7 @@ SCHEMA_SQL: tuple[dict[str, str], ...] = (
             password_hash varchar(255) not null,
             password_salt varchar(255) not null,
             iterations integer not null default 240000,
+            identity_source varchar(32) not null default 'local',
             status varchar(50) not null default 'active',
             created_at datetime not null default current_timestamp,
             updated_at datetime not null default current_timestamp,
@@ -183,7 +186,23 @@ class AuthorizationError(Exception):
 # Tables this module owns. Declared as a bundle rather than applied by a hand-written
 # dispatch loop: the loop was duplicated in six modules and had to reach into
 # `database` for private helpers, which is technical debt items 3 and 5.
-SCHEMA = SchemaBundle(name="auth", tables=SCHEMA_SQL)
+SCHEMA = SchemaBundle(
+    name="auth",
+    tables=SCHEMA_SQL,
+    table_names=["platform_user", "user_session"],
+    # Added after `platform_user` shipped, so `create table if not exists` would not reach
+    # an existing deployment. The default is `local` because that is what every account
+    # predating SSO is; migration 0001 then reclassifies the ones SSO created.
+    columns=[
+        ColumnAddition(
+            table="platform_user",
+            column="identity_source",
+            sqlite_type="text not null default 'local'",
+            postgresql_type="text not null default 'local'",
+            mysql_type="varchar(32) not null default 'local'",
+        )
+    ],
+)
 
 
 def init_auth_schema(conn: Any) -> None:
@@ -371,7 +390,8 @@ def login(
     with connect(platform_db) as conn:
         row = conn.execute(
             """
-            select id, username, display_name, role_code, status, password_hash, password_salt, iterations
+            select id, username, display_name, role_code, status, password_hash, password_salt,
+                   iterations, identity_source
             from platform_user where username = ?
             """,
             (normalized,),
@@ -381,7 +401,16 @@ def login(
         stored_salt = row["password_salt"] if row is not None else "0" * 32
         iterations = int(row["iterations"]) if row is not None else PBKDF2_ITERATIONS
         valid = verify_password(password, stored_hash, stored_salt, iterations)
-        if row is None or not valid:
+        # An SSO account is refused explicitly, and the KDF still ran above so the refusal
+        # costs the same as a wrong password -- otherwise the response time would reveal
+        # which accounts are federated.
+        #
+        # An empty hash already made `verify_password` return False, so this changes no
+        # outcome today. It changes what the code *relies on*: the protection was a side
+        # effect of a guard clause in another function, and anyone loosening that clause
+        # would have opened password login on every SSO account without touching this file.
+        federated = row is not None and (row["identity_source"] or "local") != "local"
+        if row is None or not valid or federated:
             raise AuthenticationError("用户名或密码不正确")
         if row["status"] != "active":
             raise AuthenticationError("用户已被禁用")

--- a/backend/ontology_platform/bootstrap.py
+++ b/backend/ontology_platform/bootstrap.py
@@ -1,0 +1,80 @@
+"""One place that brings a platform database up to date.
+
+The HTTP startup and the CLI's `init` each enumerated every feature schema, in two lists
+that had to stay in step. They did not have to disagree loudly to cause damage: a schema
+missing from one list produces a database where a feature returns empty results rather
+than an error, and "the knowledge base has no entries" reads as a data problem for a long
+time before anyone suspects a missing table.
+
+So the sequence is declared once here, and both entry points call it.
+
+## Order is part of the contract
+
+Base tables, then feature tables, then migrations. Migrations run **last** because they
+alter what the earlier steps created -- a backfill against a column that the current boot
+is adding must see the column already there.
+
+`seed_*` runs after migrations for the same reason in reverse: seeded rows must land in
+the final shape, not in a shape a migration is about to change.
+
+Stability: internal.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from .agent_roles import init_agent_role_schema
+from .aggregation import init_aggregate_schema
+from .auth import init_auth_schema
+from .axioms import init_axiom_schema
+from .conversations import init_conversation_schema
+from .entity_resolution import init_entity_resolution_schema
+from .events import init_event_schema
+from .knowledge_documents import init_knowledge_schema
+from .migrations import apply_migrations, init_migration_schema
+from .quotas import init_quota_schema
+from .sso import init_sso_schema
+from .temporal import init_temporal_schema
+from .workflow_permission import init_workflow_and_permission_schema
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["FEATURE_SCHEMAS", "prepare_database"]
+
+# Every feature schema, in dependency order. Enumerated rather than discovered: a plugin
+# scanner would make "which tables should exist" depend on what happens to be importable,
+# and a feature whose schema silently did not run returns empty results rather than
+# failing.
+FEATURE_SCHEMAS: tuple[Callable[[Any], None], ...] = (
+    init_workflow_and_permission_schema,
+    init_auth_schema,
+    init_agent_role_schema,
+    init_knowledge_schema,
+    init_aggregate_schema,
+    init_conversation_schema,
+    init_event_schema,
+    init_temporal_schema,
+    init_entity_resolution_schema,
+    init_axiom_schema,
+    init_quota_schema,
+    init_sso_schema,
+    init_migration_schema,
+)
+
+
+def prepare_database(conn: Any) -> list[dict[str, Any]]:
+    """Create every feature schema, then apply pending migrations.
+
+    Returns what the migrations did, so a caller can log or report it. Schema creation is
+    idempotent and reports nothing -- there is no useful distinction between "created" and
+    "already there" on a boot.
+
+    Failures are not swallowed: a missing table becomes a confusing 500 on first use rather
+    than a clear startup failure, which is the trade this platform already refuses
+    elsewhere.
+    """
+    for initialise in FEATURE_SCHEMAS:
+        initialise(conn)
+    return apply_migrations(conn)

--- a/backend/ontology_platform/cli.py
+++ b/backend/ontology_platform/cli.py
@@ -102,39 +102,29 @@ def cmd_init(args: argparse.Namespace) -> int:
 
 
 def _init_optional_schemas(conn: Any) -> None:
-    """Create every feature schema the HTTP startup would create.
+    """Bring the database up to date: feature schemas, then pending migrations.
 
-    Enumerated rather than discovered, because a schema silently missing from a
-    CLI-initialised database shows up much later as "this feature returns nothing".
+    Delegates to `bootstrap` rather than listing the schemas here. The list used to exist
+    in two places -- this function and the HTTP startup -- and a schema missing from one
+    produces a database where a feature returns empty results rather than an error, which
+    reads as a data problem for a long time before anyone suspects a missing table.
     """
-    from .agent_roles import init_agent_role_schema
-    from .aggregation import init_aggregate_schema
-    from .auth import init_auth_schema
-    from .axioms import init_axiom_schema
-    from .conversations import init_conversation_schema
-    from .entity_resolution import init_entity_resolution_schema
-    from .events import init_event_schema
-    from .knowledge_documents import init_knowledge_schema
-    from .quotas import init_quota_schema
-    from .sso import init_sso_schema
-    from .temporal import init_temporal_schema
-    from .workflow_permission import init_workflow_and_permission_schema
+    from .bootstrap import prepare_database
 
-    for initialise in (
-        init_workflow_and_permission_schema,
-        init_auth_schema,
-        init_agent_role_schema,
-        init_knowledge_schema,
-        init_aggregate_schema,
-        init_conversation_schema,
-        init_event_schema,
-        init_temporal_schema,
-        init_entity_resolution_schema,
-        init_axiom_schema,
-        init_quota_schema,
-        init_sso_schema,
-    ):
-        initialise(conn)
+    applied = prepare_database(conn)
+    for entry in applied:
+        if entry["status"] == "applied":
+            _log_migration(entry)
+
+
+def _log_migration(entry: dict[str, Any]) -> None:
+    """Report an applied migration on stderr.
+
+    On stderr rather than stdout because `init` and `demo --quiet` promise exactly one JSON
+    document on stdout, and a caller parsing that stream must not have to filter progress
+    lines out of it.
+    """
+    print(f"[migration] {entry['version']} {entry.get('description', '')}", file=sys.stderr)
 
 
 def cmd_connect(args: argparse.Namespace) -> int:

--- a/backend/ontology_platform/migrations.py
+++ b/backend/ontology_platform/migrations.py
@@ -1,0 +1,329 @@
+"""Versioned schema migrations: the changes `SchemaBundle` cannot express.
+
+`SchemaBundle` handles the two shapes that are idempotent by construction: create a table
+if absent, add a column if absent. Both are safe to re-run because the catalog says
+whether the work is already done.
+
+Everything else is not. Renaming a column, narrowing a type, backfilling a value,
+dropping a table that is no longer used, splitting one column into two -- none of those
+can be derived from the catalog, because the catalog cannot tell "already migrated" from
+"never had this shape". Running such a step twice corrupts data; skipping it leaves a
+database the code no longer matches.
+
+So this module records **which steps have run**, in the database itself.
+
+## Why not Alembic
+
+ROADMAP named Alembic as the destination and recorded the blocker as "a migration has to
+belong to a distribution, so this waits for the package split". That reasoning was
+incomplete, and the real blocker is more basic: **Alembic requires SQLAlchemy**, and the
+kernel is dependency-free by design (`pyproject` asserts it, CI verifies it on a bare
+install). Adopting Alembic would mean the ontology, rule engine and decision records
+could no longer be embedded in someone else's application without dragging in an ORM.
+
+What Alembic actually provides that this project lacks is narrow: a version ledger and
+ordered application. Autogeneration is unusable here anyway -- the DDL is declared per
+dialect as strings rather than as model metadata, so there is nothing to diff against.
+
+This is therefore not a stopgap awaiting Alembic. It is the mechanism, sized to what the
+problem needs: 150 lines, no dependencies, and the same three dialects the rest of the
+platform supports.
+
+## Every step declares its own dialects
+
+No portable DDL abstraction. `alter table ... alter column` differs across all three
+engines, and SQLite cannot alter a column at all -- the accepted approach there is
+create-copy-drop-rename. A layer pretending otherwise would generate SQL that works on
+the dialect it was tested against, which is how a migration corrupts one deployment and
+not another.
+
+Declaring per dialect makes the difference visible in review, where it can be checked.
+
+## Failure stops the sequence
+
+A migration that raises is not recorded, and no later migration runs. The alternative --
+continue and report at the end -- would apply step 7 to a database that failed step 5,
+and step 7's assumptions about the schema no longer hold. Stopping leaves a database that
+is behind, which is recoverable; continuing leaves one that is inconsistent, which may
+not be.
+
+Stability: internal. Third-party plugins declare their own migrations through
+`register_migrations`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from .schema import SchemaBundle, dialect_of, statement_for, table_exists
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MIGRATIONS",
+    "SCHEMA",
+    "Migration",
+    "MigrationError",
+    "applied_versions",
+    "apply_migrations",
+    "init_migration_schema",
+    "pending_migrations",
+    "register_migrations",
+]
+
+SCHEMA = SchemaBundle(
+    name="migrations",
+    tables=[
+        {
+            "sqlite": (
+                "create table if not exists schema_migration ("
+                "version text primary key,"
+                " description text not null default '',"
+                " applied_at text not null default current_timestamp)"
+            ),
+            "postgresql": (
+                "create table if not exists schema_migration ("
+                "version text primary key,"
+                " description text not null default '',"
+                " applied_at timestamp not null default current_timestamp)"
+            ),
+            "mysql": (
+                "create table if not exists schema_migration ("
+                "version varchar(64) primary key,"
+                " description text not null,"
+                " applied_at datetime not null default current_timestamp)"
+            ),
+        }
+    ],
+    table_names=["schema_migration"],
+)
+
+
+class MigrationError(RuntimeError):
+    """Raised when a migration fails, naming the version that stopped the sequence."""
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One irreversible schema change, applied at most once per database.
+
+    `version` is the identity recorded in `schema_migration`, so it must never be reused
+    or reordered: a database that already ran `0003` will skip any future migration that
+    reuses that version, whatever it does.
+
+    `statements` is keyed by dialect. A dialect absent from the mapping means "no work on
+    this engine" rather than an error -- a PostgreSQL-only index has nothing to do on
+    SQLite, and forcing an empty entry would make every migration list three keys to say
+    one thing.
+
+    `guard_table` skips the migration when the table is absent -- a plugin's migration has
+    nothing to do on a deployment that never installed that plugin.
+
+    `skip_when_empty` skips it when the named table has no rows. That is what makes a
+    backfill safe on a *fresh* install: the column ships with the right default and there
+    are no rows to reclassify, so running the update would be work with no subject. Checked
+    rather than assumed, because "the table exists" is true on a fresh install too -- the
+    base DDL creates it -- so a table probe alone would never skip anything.
+    """
+
+    version: str
+    description: str
+    statements: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    guard_table: str = ""
+    skip_when_empty: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.version.strip():
+            raise MigrationError("迁移必须有版本号")
+        if not self.description.strip():
+            # A migration nobody can identify from the ledger is a migration nobody can
+            # reason about during an incident.
+            raise MigrationError(f"迁移 {self.version} 必须有描述")
+
+    def statements_for(self, dialect: str) -> tuple[str, ...]:
+        return tuple(self.statements.get(dialect, ()))
+
+
+# The platform's own migrations, in application order.
+MIGRATIONS: list[Migration] = [
+    Migration(
+        version="0001",
+        description="回填 platform_user.identity_source：把「无口令即 SSO」的约定变成声明",
+        # SSO provisioning writes `password_hash = ''` to mean "this account has no
+        # password", and `verify_password` returns False on an empty hash, so a password
+        # login against an SSO account fails. That works, and it works *by coincidence* --
+        # the protection is a side effect of one function's guard clause rather than a
+        # property of the record.
+        #
+        # The column makes it a declaration. This is exactly the shape `SchemaBundle`
+        # cannot express: the column addition is idempotent, but **the backfill is not**.
+        # Re-running it would relabel any account whose password was legitimately removed
+        # later, and the catalog cannot distinguish "not yet backfilled" from "backfilled,
+        # then changed".
+        #
+        # Existing rows are classified by the only evidence available: an empty hash means
+        # the account was provisioned by SSO, because nothing else produces one.
+        statements={
+            "sqlite": [
+                "update platform_user set identity_source = 'sso' where (password_hash is null or password_hash = '')",
+                "update platform_user set identity_source = 'local'"
+                " where password_hash is not null and password_hash <> ''",
+            ],
+            "postgresql": [
+                "update platform_user set identity_source = 'sso' where (password_hash is null or password_hash = '')",
+                "update platform_user set identity_source = 'local'"
+                " where password_hash is not null and password_hash <> ''",
+            ],
+            "mysql": [
+                "update platform_user set identity_source = 'sso' where (password_hash is null or password_hash = '')",
+                "update platform_user set identity_source = 'local'"
+                " where password_hash is not null and password_hash <> ''",
+            ],
+        },
+        guard_table="platform_user",
+        # Skipped on a fresh install: the column ships defaulting to `local` and there are
+        # no rows to reclassify. A table probe alone would never skip, because the base DDL
+        # creates `platform_user` on every install.
+        skip_when_empty="platform_user",
+    ),
+]
+
+_PLUGIN_MIGRATIONS: list[Migration] = []
+
+
+def register_migrations(migrations: Sequence[Migration]) -> None:
+    """Add a plugin's migrations to the sequence.
+
+    Appended after the platform's own, because a plugin's schema depends on the platform's
+    and not the reverse. Versions must be unique across everything registered: a plugin
+    reusing a platform version would be silently skipped on any database that ran it.
+    """
+    known = {migration.version for migration in (*MIGRATIONS, *_PLUGIN_MIGRATIONS)}
+    for migration in migrations:
+        if migration.version in known:
+            raise MigrationError(f"迁移版本重复: {migration.version}")
+        known.add(migration.version)
+        _PLUGIN_MIGRATIONS.append(migration)
+
+
+def _all_migrations() -> tuple[Migration, ...]:
+    return (*MIGRATIONS, *_PLUGIN_MIGRATIONS)
+
+
+def init_migration_schema(conn: Any) -> None:
+    SCHEMA.apply(conn)
+
+
+def applied_versions(conn: Any) -> set[str]:
+    """Versions this database has already run.
+
+    An absent ledger reads as "nothing applied" rather than as an error: that is exactly
+    the state of a database created before migrations existed, and every such database
+    must be able to catch up.
+    """
+    if not table_exists(conn, "schema_migration"):
+        return set()
+    rows = conn.execute("select version from schema_migration").fetchall()
+    return {row["version"] if hasattr(row, "keys") else row[0] for row in rows}
+
+
+def pending_migrations(conn: Any) -> list[Migration]:
+    applied = applied_versions(conn)
+    return [migration for migration in _all_migrations() if migration.version not in applied]
+
+
+def apply_migrations(conn: Any) -> list[dict[str, Any]]:
+    """Run every unapplied migration, in order, stopping at the first failure.
+
+    Each migration is recorded in the same transaction as its own statements where the
+    dialect allows it, so a crash between "changed the schema" and "recorded that we did"
+    cannot happen silently. On a crash *before* the record, the migration is retried --
+    which is why a migration should be written to tolerate a partial previous attempt
+    wherever the dialect cannot make it atomic.
+    """
+    init_migration_schema(conn)
+    dialect = dialect_of(conn)
+    results: list[dict[str, Any]] = []
+
+    for migration in pending_migrations(conn):
+        statements = migration.statements_for(dialect)
+        if migration.guard_table and not table_exists(conn, migration.guard_table):
+            # The feature owning this table is not installed. Recorded so it is not retried
+            # on every boot forever.
+            _record(conn, migration, dialect, skipped=True)
+            results.append({"version": migration.version, "status": "skipped", "reason": "表不存在"})
+            continue
+        if migration.skip_when_empty and _is_empty(conn, migration.skip_when_empty):
+            # Fresh install: nothing to backfill, because the column shipped with the
+            # correct default and there are no rows.
+            _record(conn, migration, dialect, skipped=True)
+            results.append({"version": migration.version, "status": "skipped", "reason": "无数据需回填"})
+            continue
+        if not statements:
+            _record(conn, migration, dialect, skipped=True)
+            results.append({"version": migration.version, "status": "skipped", "reason": f"{dialect} 无需变更"})
+            continue
+
+        try:
+            for statement in statements:
+                _execute(conn, statement, dialect)
+            _record(conn, migration, dialect)
+        except Exception as error:
+            # Not recorded, and the sequence stops: applying step 7 to a database that
+            # failed step 5 means step 7's assumptions about the schema no longer hold.
+            logger.error("迁移 %s 失败，已停止后续迁移: %s", migration.version, error)
+            raise MigrationError(
+                f"迁移 {migration.version}（{migration.description}）失败，后续迁移未执行: {error}"
+            ) from error
+
+        results.append({"version": migration.version, "status": "applied", "description": migration.description})
+
+    return results
+
+
+def _execute(conn: Any, statement: str, dialect: str) -> None:
+    if dialect == "sqlite":
+        conn.execute(statement)
+    else:
+        with conn.cursor() as cursor:
+            cursor.execute(statement)
+
+
+def _is_empty(conn: Any, table: str) -> bool:
+    """Whether a table has no rows.
+
+    A table that cannot be read counts as empty: the alternative is failing a migration
+    because of a probe, which turns a skippable step into a stopped upgrade.
+    """
+    if not table_exists(conn, table):
+        return True
+    try:
+        row = conn.execute(f"select count(*) as total from {table}").fetchone()
+    except Exception as error:  # pragma: no cover - driver-specific
+        logger.debug("迁移探测表 %s 行数失败，按空表处理: %s", table, error)
+        return True
+    if row is None:
+        return True
+    total = row["total"] if hasattr(row, "keys") else row[0]
+    return int(total) == 0
+
+
+def _record(conn: Any, migration: Migration, dialect: str, *, skipped: bool = False) -> None:
+    description = migration.description + ("（跳过）" if skipped else "")
+    insert = statement_for(
+        {
+            "sqlite": "insert into schema_migration (version, description) values (?, ?)",
+            "postgresql": "insert into schema_migration (version, description) values (%s, %s)",
+            "mysql": "insert into schema_migration (version, description) values (%s, %s)",
+        },
+        dialect,
+    )
+    if dialect == "sqlite":
+        conn.execute(insert, (migration.version, description))
+    else:
+        with conn.cursor() as cursor:
+            cursor.execute(insert, (migration.version, description))
+    if hasattr(conn, "commit"):
+        conn.commit()

--- a/backend/ontology_platform/sso.py
+++ b/backend/ontology_platform/sso.py
@@ -423,8 +423,13 @@ def login_with_assertion(
 
         if row is None:
             conn.execute(
+                # `identity_source` is declared rather than inferred from an empty hash.
+                # The empty hash still blocks a password login, but that protection was a
+                # side effect of `verify_password`'s guard clause; this makes it a property
+                # of the record, which is what `login` can then check deliberately.
                 "insert into platform_user (username, display_name, role_code, password_hash,"
-                " password_salt, iterations, status) values (?, ?, ?, '', '', 0, 'active')",
+                " password_salt, iterations, identity_source, status)"
+                " values (?, ?, ?, '', '', 0, 'sso', 'active')",
                 (username, display_name, role_code),
             )
             user_id = int(conn.execute("select id from platform_user where username = ?", (username,)).fetchone()["id"])

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,272 @@
+"""Versioned migrations: the schema changes `SchemaBundle` cannot express.
+
+`SchemaBundle` covers the two idempotent shapes -- create a table if absent, add a column
+if absent -- because the catalog can answer whether the work is done. Nothing else is
+safe to re-run: renaming a column, narrowing a type, backfilling a value, dropping a table
+that is no longer used. The catalog cannot distinguish "not yet migrated" from "migrated,
+then legitimately changed", so running such a step twice corrupts data.
+
+ROADMAP recorded Alembic as the destination, blocked on the package split. The real
+blocker was more basic: **Alembic requires SQLAlchemy**, and the kernel is dependency-free
+by design -- CI verifies it on a bare install. What Alembic provides that this project
+lacked is narrow (a version ledger and ordered application), and autogeneration is
+unusable here anyway because the DDL is declared per dialect as strings.
+
+The properties worth pinning down:
+
+- **an existing deployment catches up**, including one created before migrations existed
+- **a fresh install skips the backfill**, because the column ships with the right default
+  and there are no rows to reclassify
+- **re-running changes nothing**, which is what the ledger is for
+- **a failure stops the sequence**, because applying step 7 to a database that failed
+  step 5 means step 7's assumptions no longer hold
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from ontology_platform.bootstrap import FEATURE_SCHEMAS, prepare_database
+from ontology_platform.database import connect, initialize_platform_db
+from ontology_platform.migrations import (
+    MIGRATIONS,
+    Migration,
+    MigrationError,
+    applied_versions,
+    apply_migrations,
+    pending_migrations,
+    register_migrations,
+)
+
+
+def _legacy_database(path: Path, *, users: bool = True) -> Path:
+    """A platform database as it existed before `identity_source` or the ledger.
+
+    Hand-built rather than produced by an old release, because the property under test is
+    "an existing deployment catches up" and the only honest way to check it is to start
+    from a schema that genuinely lacks the column.
+    """
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        create table platform_user (
+            id integer primary key autoincrement,
+            username text not null unique,
+            display_name text not null default '',
+            role_code text not null default 'analyst',
+            password_hash text not null,
+            password_salt text not null,
+            iterations integer not null default 240000,
+            status text not null default 'active',
+            created_at text not null default current_timestamp,
+            updated_at text not null default current_timestamp,
+            last_login_at text
+        );
+        """
+    )
+    if users:
+        connection.executescript(
+            """
+            insert into platform_user (username, password_hash, password_salt)
+                values ('local.user', 'abc123', 'saltx');
+            insert into platform_user (username, password_hash, password_salt, iterations)
+                values ('sso.user', '', '', 0);
+            """
+        )
+    connection.commit()
+    connection.close()
+    return path
+
+
+# -- Declaration --
+
+
+def test_a_migration_without_a_description_is_refused() -> None:
+    """A migration nobody can identify from the ledger is one nobody can reason about
+    during an incident."""
+    with pytest.raises(MigrationError, match="必须有描述"):
+        Migration(version="9999", description="")
+
+
+def test_a_migration_without_a_version_is_refused() -> None:
+    with pytest.raises(MigrationError, match="必须有版本号"):
+        Migration(version="  ", description="something")
+
+
+def test_a_duplicate_version_is_refused() -> None:
+    """A plugin reusing a platform version would be silently skipped on any database that
+    already ran it -- the schema change would simply never happen."""
+    with pytest.raises(MigrationError, match="版本重复"):
+        register_migrations([Migration(version=MIGRATIONS[0].version, description="clash")])
+
+
+def test_every_platform_migration_declares_all_three_dialects() -> None:
+    """A dialect missing from a migration silently does nothing on that engine.
+
+    That is a legitimate shape for a PostgreSQL-only index, but not for a backfill: it
+    would leave MySQL deployments with unmigrated data and no indication of it. So the
+    platform's own migrations are required to be explicit about all three.
+    """
+    for migration in MIGRATIONS:
+        for dialect in ("sqlite", "postgresql", "mysql"):
+            assert migration.statements_for(dialect), f"迁移 {migration.version} 未声明 {dialect} 语句"
+
+
+# -- Catching up an existing deployment --
+
+
+def test_a_legacy_database_is_reclassified(tmp_path: Path) -> None:
+    """The backfill that is not idempotent, and therefore needs the ledger.
+
+    Accounts are classified by the only evidence available: an empty password hash means
+    SSO provisioned the row, because nothing else produces one. Re-running this against a
+    database where a password was legitimately removed later would relabel that account,
+    which is exactly why it must run once.
+    """
+    database = _legacy_database(tmp_path / "legacy.sqlite3")
+    initialize_platform_db(database)
+
+    with connect(database) as conn:
+        applied = prepare_database(conn)
+
+    assert [(item["version"], item["status"]) for item in applied] == [("0001", "applied")]
+
+    with connect(database) as conn:
+        sources = {
+            row["username"]: row["identity_source"]
+            for row in conn.execute("select username, identity_source from platform_user").fetchall()
+        }
+    assert sources == {"local.user": "local", "sso.user": "sso"}
+
+
+def test_re_running_applies_nothing(tmp_path: Path) -> None:
+    """What the ledger exists for. Without it the backfill would run on every boot."""
+    database = _legacy_database(tmp_path / "legacy.sqlite3")
+    initialize_platform_db(database)
+    with connect(database) as conn:
+        prepare_database(conn)
+        assert prepare_database(conn) == []
+
+
+def test_a_database_predating_the_ledger_reads_as_nothing_applied(tmp_path: Path) -> None:
+    """An absent ledger must not be an error: that is the state of every database created
+    before migrations existed, and all of them have to be able to catch up."""
+    database = _legacy_database(tmp_path / "legacy.sqlite3")
+    with connect(database) as conn:
+        assert applied_versions(conn) == set()
+        assert [item.version for item in pending_migrations(conn)] == [item.version for item in MIGRATIONS]
+
+
+# -- A fresh install has nothing to backfill --
+
+
+def test_a_fresh_install_skips_the_backfill(tmp_path: Path) -> None:
+    """The column ships defaulting to `local` and there are no rows to reclassify.
+
+    Skipped rather than applied, and *recorded* as skipped: an unrecorded skip would be
+    retried on every boot forever.
+    """
+    database = tmp_path / "fresh.sqlite3"
+    initialize_platform_db(database)
+    with connect(database) as conn:
+        applied = prepare_database(conn)
+
+    assert [(item["version"], item["status"]) for item in applied] == [("0001", "skipped")]
+    with connect(database) as conn:
+        assert applied_versions(conn) == {"0001"}
+
+
+def test_a_table_probe_alone_would_never_skip(tmp_path: Path) -> None:
+    """Why `skip_when_empty` exists rather than only `guard_table`.
+
+    `platform_user` is created by `init_auth_schema`, which runs before migrations in the
+    bootstrap sequence -- so by the time the backfill is considered, the table exists on a
+    fresh install too. A table probe would report "present" and run the update against zero
+    rows on every new deployment. Harmless for this migration, and the wrong mechanism: the
+    next backfill might not be idempotent against an empty table.
+    """
+    database = tmp_path / "fresh.sqlite3"
+    initialize_platform_db(database)
+    with connect(database) as conn:
+        from ontology_platform.schema import table_exists
+
+        assert not table_exists(conn, "platform_user"), "认证表尚未建立"
+        prepare_database(conn)
+        assert table_exists(conn, "platform_user"), "引导序列应已创建该表"
+        assert MIGRATIONS[0].skip_when_empty == "platform_user"
+
+
+# -- Failure stops the sequence --
+
+
+def test_a_failing_migration_stops_the_ones_after_it(tmp_path: Path) -> None:
+    """Applying step 7 to a database that failed step 5 means step 7's assumptions about
+    the schema no longer hold. Behind is recoverable; inconsistent may not be.
+    """
+    database = tmp_path / "fresh.sqlite3"
+    initialize_platform_db(database)
+
+    broken = Migration(
+        version="t900",
+        description="故意失败",
+        statements={"sqlite": ["update table_that_does_not_exist set x = 1"]},
+    )
+    following = Migration(
+        version="t901",
+        description="不应被执行",
+        statements={"sqlite": ["create table should_not_exist (id integer)"]},
+    )
+    register_migrations([broken, following])
+    try:
+        with connect(database) as conn:
+            with pytest.raises(MigrationError, match="t900"):
+                apply_migrations(conn)
+
+        with connect(database) as conn:
+            from ontology_platform.schema import table_exists
+
+            recorded = applied_versions(conn)
+            assert "t900" not in recorded, "失败的迁移不应被记录，否则永不重试"
+            assert "t901" not in recorded
+            assert not table_exists(conn, "should_not_exist"), "后续迁移不应执行"
+    finally:
+        # Registered migrations are process-global; leaving them would fail every later test.
+        from ontology_platform import migrations as module
+
+        module._PLUGIN_MIGRATIONS.clear()
+
+
+# -- The single bootstrap sequence --
+
+
+def test_migrations_run_after_every_feature_schema(tmp_path: Path) -> None:
+    """Order is part of the contract: a backfill against a column this boot is adding must
+    see the column already there."""
+    from ontology_platform.migrations import init_migration_schema
+
+    assert FEATURE_SCHEMAS[-1] is init_migration_schema, "迁移账本应在特性表之后建立"
+
+
+def test_the_bootstrap_sequence_covers_every_feature_schema() -> None:
+    """The list used to exist twice -- here and in the HTTP startup -- and a schema missing
+    from one produces a database where a feature returns empty results rather than an
+    error, which reads as a data problem long before anyone suspects a missing table.
+    """
+    import re
+
+    api = (ROOT / "backend" / "ontology_platform" / "api.py").read_text(encoding="utf-8")
+    cli = (ROOT / "backend" / "ontology_platform" / "cli.py").read_text(encoding="utf-8")
+
+    assert "prepare_database" in api, "HTTP 启动应走统一的引导序列"
+    assert "prepare_database" in cli, "CLI init 应走统一的引导序列"
+    # And neither may keep its own list, or the two would drift again.
+    for source, name in ((api, "api.py"), (cli, "cli.py")):
+        stray = re.findall(r"init_\w+_schema\(conn\)", source)
+        assert not stray, f"{name} 仍在自行枚举特性表: {stray}"


### PR DESCRIPTION
## `SchemaBundle` 覆盖不到的那一半

现有机制处理两种**构造上幂等**的变更：建表（若不存在）、加列（若不存在）。目录能回答「这活干过了吗」，所以重跑安全。

其余都不安全：**改列名、收窄类型、回填取值、删掉不再使用的表**——对这些，目录无法区分「还没迁移」和「迁移过、后来又正当地改了」。跑两次会损坏数据，不跑则留下一个代码已不匹配的库。**平台此前没有地方放这种变更。**

## Alembic 的阻塞理由是错的

ROADMAP 记的是「迁移需归属于某个分发包，因此阻塞于分包边界」。那个理由不完整。

真正的阻塞更基本：**Alembic 依赖 SQLAlchemy**，而内核零依赖是明确承诺——`pyproject` 声明它、CI 在裸装环境校验它。采用 Alembic 意味着本体、规则引擎与决策留痕**再也无法嵌入别人的应用而不拖进一个 ORM**。

而 Alembic 真正提供、本项目缺的只有两点：**版本账本**与**有序应用**。自动生成在此本就不可用——DDL 是按方言声明的字符串，没有模型元数据可 diff。

所以这不是等待 Alembic 的权宜之计，而是按问题规模给出的机制：150 行、零依赖、同样三个方言。

**不做可移植 DDL 抽象。** `alter table ... alter column` 在三个引擎上各不相同，而 SQLite 根本不能改列。每一步各自声明方言，差异在评审时可见。假装可移植的抽象只会生成「在被测过的那个方言上能用」的 SQL——那正是一次迁移损坏一个部署而不损坏另一个的方式。

**失败即中止后续**，而非继续执行、最后汇总。把第 7 步用在第 5 步失败的库上，意味着第 7 步对 schema 的假设已不成立：落后是可恢复的，不一致可能不是。

## 第一条迁移是真实的，不是占位

SSO 建号时写 `password_hash = ''` 表示「无口令」，而 `verify_password` 对空 hash 返回 False——于是 SSO 账号的口令登录**靠巧合被挡住**：保护来自另一个函数里的一句 guard clause 的副作用。

**任何人放宽那句 clause，都会在不碰 `login` 的情况下，为所有联邦账号打开口令登录。**

`identity_source` 把它变成记录自身的属性，`login` 现在显式检查它——且在 KDF 跑完之后，使拒绝的耗时与口令错误相同，否则响应时间会泄露哪些账号是联邦的。

这个回填正是需要账本的形状：**加列幂等，重新分类不幂等。** 重跑会把「后来正当移除了口令」的账号错误改标。

`skip_when_empty` 处理全新安装——列自带正确默认值、没有行需要重分类。**仅靠表探测永不会跳过**，因为引导序列在迁移之前就创建了 `platform_user`。

## 引导序列合并为一处

它此前存在两份：HTTP 启动与 CLI `init`。漏掉一个不会响亮地失败——它产生的库会让某个功能**返回空结果而非报错**，而「知识库里没有条目」在很长时间里都会被当成数据问题。

测试断言两个入口都不再自行枚举。

## 验证

对一个手工构造的「迁移机制之前」的库实测：两个账号都正确重分类、二次运行无变更、全新安装记录为跳过、故意失败的迁移不被记录且后一条未执行。

3.11／3.12／3.13 各 1177 通过。