### PR TITLE
derive 补齐工作流与规则求值列：清空「字段存在但逻辑未生效」

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -657,7 +657,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**1214 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
+**1221 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
 no server is reachable.
 
 | File | Count | Covers |

--- a/README.md
+++ b/README.md
@@ -644,13 +644,17 @@ _不是_：算法、模型、策略引擎脚本。
 
 ### 字段存在但逻辑未生效
 
-这类最危险，因为接口看起来能用：
+**本节已清空。** 这类最危险，因为接口看起来能用——所以逐项记录它们是如何消失的：
 
-> 此前列在本节的四项已修复：`guard_expression`、`filter_expression`、
-> `depends_on` 现已真实生效，`permission_policy` 已带本体维度。三者均为
-> fail-closed：无法求值时拒绝而非放行。
+> - `guard_expression`、`filter_expression`、`depends_on` 现已真实生效，
+>   `permission_policy` 已带本体维度。四者均为 fail-closed：无法求值时拒绝而非放行。
+> - `derive` 新版本现已复制工作流定义与规则的求值列（`priority`、生效期、`depends_on`）。
+>   此前它们被丢弃，而那不只是丢元数据：派生版本会以不同顺序、在不同生效期内求值同一批规则——
+>   「新版本给出不同判定」恰恰是 `derive` 最不该静默做的事。
+>   实例状态**刻意不复制**：定义属于模型，而某份合同当前在哪个状态属于数据。
+> - 模型配置的四个兼容性字段（`authStyle` 等）现已声明。此前前端一直在发、
+>   而 Pydantic 静默丢弃，于是界面报成功而 Azure 与本地 vLLM 配不上。
 
-- **工作流与本体版本脱钩** —— `derive` 新版本不复制工作流配置。
 
 ### 结构性表达力约束
 
@@ -938,7 +942,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**1214 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
+**1221 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
 对应用例自动跳过。分布：
 
 | 文件 | 数量 | 覆盖 |
@@ -952,6 +956,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_inert_fields_activated.py` | 28 | 守卫、行级过滤、规则依赖、策略本体维度 |
 | `test_conversations_and_feedback.py` | 35 | 会话持久化、反馈归因、转人工 |
 | `test_platform_context.py` | 23 | 多实例隔离、线程绑定、向后兼容 |
+| `test_derive_completeness.py` | 7 | 派生新版本复制工作流与规则求值列，但不复制实例状态 |
 | `test_codegen.py` | 16 | 关系类型化为目标对象、仅已发布本体、产物通过真实 tsc --strict |
 | `test_scaffold.py` | 19 | 生成的代码被真实执行：能编译、能注册、能建库、不含平台私有引用 |
 | `test_migrations.py` | 12 | 旧库补齐、新装跳过、重跑无变更、失败即中止后续 |

--- a/backend/ontology_platform/governance.py
+++ b/backend/ontology_platform/governance.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .database import connect, last_insert_id
 from .release_readiness import assess_ontology_release_readiness
+from .schema import table_exists
 from .semantic_kernel import validate_rule_expression
 from .type_hierarchy import inherited_rule_scopes
 
@@ -246,6 +247,7 @@ def derive_ontology_version(
             conn, source_ontology_id, new_ontology_id, object_id_map, attribute_id_map, source["version"]
         )
         rule_count = _copy_business_rules(conn, source_ontology_id, new_ontology_id)
+        workflow_count = _copy_workflows(conn, source_ontology_id, new_ontology_id)
 
         conn.execute(
             "insert into audit_log (actor, action, target_type, target_id, detail) values (?, ?, ?, ?, ?)",
@@ -261,6 +263,7 @@ def derive_ontology_version(
                         "newVersion": version,
                         "mappings": mapping_count,
                         "rules": rule_count,
+                        "workflows": workflow_count,
                     },
                     ensure_ascii=False,
                 ),
@@ -722,9 +725,10 @@ def _copy_business_rules(conn: Any, source_ontology_id: int, new_ontology_id: in
             """
             insert into business_rule (
                 ontology_id, code, name, rule_type, scope_object_code,
-                expression, severity, natural_language, status
+                expression, severity, natural_language, status,
+                priority, category, effective_start, effective_end, depends_on
             )
-            values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 new_ontology_id,
@@ -736,9 +740,132 @@ def _copy_business_rules(conn: Any, source_ontology_id: int, new_ontology_id: in
                 rule["severity"],
                 rule["natural_language"],
                 rule["status"],
+                # These five were dropped, which changed behaviour rather than only losing
+                # metadata: `priority` decides evaluation order, `effective_start`/`_end`
+                # decide whether a rule applies at all, and `depends_on` is read by the
+                # engine. A derived version therefore evaluated the same rules differently
+                # from the version it came from -- and "the new version gives a different
+                # verdict" is the one thing `derive` must not do silently.
+                _rule_column(rule, "priority", 0),
+                _rule_column(rule, "category", ""),
+                _rule_column(rule, "effective_start", None),
+                _rule_column(rule, "effective_end", None),
+                _rule_column(rule, "depends_on", "[]"),
             ),
         )
     return len(rules)
+
+
+def _rule_column(row: Any, column: str, default: Any) -> Any:
+    """One rule column, tolerating a database that predates it.
+
+    `priority`, `category`, the effective dates and `depends_on` were added after
+    `business_rule` shipped. A deployment that has not applied the column addition would
+    otherwise fail every `derive` with a KeyError -- and an upgrade that breaks derivation is
+    worse than one that derives without a column nobody set.
+    """
+    try:
+        value = row[column]
+    except (KeyError, IndexError):
+        return default
+    return default if value is None and default is not None else value
+
+
+def _copy_workflows(conn: Any, source_ontology_id: int, new_ontology_id: int) -> int:
+    """Copy workflow definitions, their states and their transitions.
+
+    Previously not copied, and recorded in README as "工作流与本体版本脱钩". The consequence
+    was concrete: deriving a new version produced an ontology whose objects had no state
+    machine, so every instance entering it had nowhere to go -- and the failure appeared as
+    "this object has no workflow", which reads as a modelling omission rather than as
+    something `derive` dropped.
+
+    **Instances are deliberately not copied.** A workflow *definition* is part of the model;
+    an instance's current state is data about a specific contract. Copying instance states
+    into a new version would assert that a contract is simultaneously at two points in two
+    state machines, and reconciling that later requires knowing which one the business
+    considers authoritative -- a question the platform cannot answer for them.
+
+    Missing tables mean the feature was never used, which is zero workflows rather than an
+    error: a deployment that never configured a workflow must still be able to derive.
+    """
+    if not table_exists(conn, "workflow_definition"):
+        return 0
+
+    definitions = conn.execute(
+        "select * from workflow_definition where ontology_id = ? order by id",
+        (source_ontology_id,),
+    ).fetchall()
+
+    for definition in definitions:
+        conn.execute(
+            """
+            insert into workflow_definition (
+                ontology_id, object_code, name, description, initial_state, status
+            )
+            values (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                new_ontology_id,
+                definition["object_code"],
+                definition["name"],
+                definition["description"],
+                definition["initial_state"],
+                definition["status"],
+            ),
+        )
+        new_workflow_id = last_insert_id(conn)
+
+        for state in conn.execute(
+            "select * from workflow_state where workflow_id = ? order by sort_order, id",
+            (int(definition["id"]),),
+        ).fetchall():
+            conn.execute(
+                """
+                insert into workflow_state (
+                    workflow_id, code, name, description, is_terminal, color, sort_order
+                )
+                values (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    new_workflow_id,
+                    state["code"],
+                    state["name"],
+                    state["description"],
+                    state["is_terminal"],
+                    state["color"],
+                    state["sort_order"],
+                ),
+            )
+
+        for transition in conn.execute(
+            "select * from workflow_transition where workflow_id = ? order by sort_order, id",
+            (int(definition["id"]),),
+        ).fetchall():
+            conn.execute(
+                """
+                insert into workflow_transition (
+                    workflow_id, from_state, to_state, action_code, name,
+                    guard_expression, requires_review, review_role, sort_order
+                )
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    new_workflow_id,
+                    transition["from_state"],
+                    transition["to_state"],
+                    transition["action_code"],
+                    transition["name"],
+                    # The guard is what makes a transition refusable. Dropping it would turn
+                    # every gated transition into an open one, silently.
+                    transition["guard_expression"],
+                    transition["requires_review"],
+                    transition["review_role"],
+                    transition["sort_order"],
+                ),
+            )
+
+    return len(definitions)
 
 
 def _remap_mapping_target(target_ref: str, object_id_map: dict[int, int], attribute_id_map: dict[int, int]) -> str:

--- a/tests/test_derive_completeness.py
+++ b/tests/test_derive_completeness.py
@@ -1,0 +1,283 @@
+"""`derive` must carry forward everything that decides a verdict.
+
+Deriving a new ontology version copies objects, attributes, relations, mappings and rules.
+Two things it did not copy were recorded in README as limitations, and both are worse than
+"missing metadata" -- they change what the new version *decides*:
+
+- **workflow definitions.** A derived version's objects had no state machine, so an instance
+  entering it had nowhere to go. The symptom was "this object has no workflow", which reads
+  as a modelling omission rather than as something `derive` dropped.
+- **five rule columns.** `priority` decides evaluation order, `effective_start`/`_end` decide
+  whether a rule applies at all, and `depends_on` is read by the engine. So a derived version
+  evaluated the same rules differently from the version it came from -- and "the new version
+  gives a different verdict" is the one thing `derive` must not do silently.
+
+What is deliberately *not* copied is instance state. A workflow definition is part of the
+model; an instance's current state is data about a specific contract. Copying it would assert
+that a contract sits at two points in two state machines at once, and reconciling that later
+needs to know which the business considers authoritative -- a question the platform cannot
+answer for them.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from ontology_platform.bootstrap import prepare_database
+from ontology_platform.database import connect, initialize_platform_db
+from ontology_platform.governance import (
+    derive_ontology_version,
+    publish_ontology,
+    upsert_business_rule,
+)
+from ontology_platform.metadata import register_data_source, scan_data_source
+from ontology_platform.ontology import generate_ontology_draft
+from ontology_platform.workflow_permission import (
+    add_workflow_transition,
+    create_workflow,
+    enter_workflow,
+)
+
+
+@pytest.fixture
+def published(tmp_path: Path):
+    source = tmp_path / "business.sqlite3"
+    sqlite3.connect(source).executescript(
+        """
+        create table contracts (
+            id integer primary key,
+            amount numeric not null,
+            status text not null
+        );
+        insert into contracts values (1, 100, 'draft');
+        """
+    )
+
+    platform_db = tmp_path / "platform.sqlite3"
+    initialize_platform_db(platform_db)
+    with connect(platform_db) as conn:
+        prepare_database(conn)
+
+    data_source = register_data_source(platform_db, "业务系统", "sqlite", str(source), domain="合同管理")
+    scan_data_source(platform_db, data_source.id)
+    ontology_id = generate_ontology_draft(platform_db, data_source.id)["ontology"]["id"]
+
+    with connect(platform_db) as conn:
+        object_code = conn.execute("select code from business_object where ontology_id = ?", (ontology_id,)).fetchone()[
+            "code"
+        ]
+
+    workflow = create_workflow(platform_db, ontology_id, object_code, "合同审批")
+    states = [state["code"] for state in workflow["states"]]
+    # A guarded, review-requiring transition: the parts of a workflow that make a transition
+    # refusable, and therefore the parts whose loss changes behaviour rather than appearance.
+    add_workflow_transition(
+        platform_db,
+        workflow["id"],
+        states[0],
+        states[-1],
+        "fast_approve",
+        "加急批准",
+        guard_expression="amount > 0",
+        requires_review=True,
+        review_role="approver",
+    )
+
+    with connect(platform_db) as conn:
+        conn.execute(
+            "update semantic_mapping set status = 'confirmed' where ontology_id = ?",
+            (ontology_id,),
+        )
+        # Rule columns that decide evaluation, set to non-default values so a dropped column
+        # is observable. All defaults would make "copied" and "re-defaulted" identical.
+        conn.execute(
+            """
+            update business_rule set priority = 7, category = '合规', depends_on = '["other_rule"]',
+                   effective_start = '2026-01-01', effective_end = '2026-12-31'
+             where ontology_id = ?
+            """,
+            (ontology_id,),
+        )
+    publish_ontology(platform_db, ontology_id, "tester")
+
+    return {
+        "platform_db": platform_db,
+        "ontology_id": ontology_id,
+        "object_code": object_code,
+        "workflow_id": workflow["id"],
+        "states": states,
+    }
+
+
+def _derive(published) -> int:
+    derived = derive_ontology_version(published["platform_db"], published["ontology_id"], "0.2.0", "架构师")
+    return int(derived.get("id") or derived["ontology"]["id"])
+
+
+# -- Workflow definitions --
+
+
+def test_the_workflow_definition_is_carried_forward(published) -> None:
+    """Without it, every object in the derived version has nowhere for an instance to go."""
+    derived_id = _derive(published)
+    with connect(published["platform_db"]) as conn:
+        definition = conn.execute(
+            "select id, object_code, initial_state, status from workflow_definition where ontology_id = ?",
+            (derived_id,),
+        ).fetchone()
+    assert definition is not None, "派生版本缺少工作流定义"
+    assert definition["object_code"] == published["object_code"]
+
+
+def test_every_state_is_carried_forward(published) -> None:
+    derived_id = _derive(published)
+    with connect(published["platform_db"]) as conn:
+        source_states = {
+            row["code"]
+            for row in conn.execute(
+                "select code from workflow_state where workflow_id = ?", (published["workflow_id"],)
+            ).fetchall()
+        }
+        derived_workflow = conn.execute(
+            "select id from workflow_definition where ontology_id = ?", (derived_id,)
+        ).fetchone()
+        derived_states = {
+            row["code"]
+            for row in conn.execute(
+                "select code from workflow_state where workflow_id = ?", (derived_workflow["id"],)
+            ).fetchall()
+        }
+    assert derived_states == source_states
+
+
+def test_a_transition_keeps_its_guard_and_review_requirement(published) -> None:
+    """The guard is what makes a transition refusable.
+
+    Dropping it would turn every gated transition into an open one -- silently, since the
+    transition still exists and still works. It would simply stop refusing anything.
+    """
+    derived_id = _derive(published)
+    with connect(published["platform_db"]) as conn:
+        derived_workflow = conn.execute(
+            "select id from workflow_definition where ontology_id = ?", (derived_id,)
+        ).fetchone()
+        transition = conn.execute(
+            "select guard_expression, requires_review, review_role from workflow_transition"
+            " where workflow_id = ? and action_code = 'fast_approve'",
+            (derived_workflow["id"],),
+        ).fetchone()
+
+    assert transition is not None, "带 guard 的流转未被复制"
+    assert transition["guard_expression"] == "amount > 0", "guard 丢失会让受限流转变成开放流转"
+    assert transition["requires_review"], "审核要求丢失"
+    assert transition["review_role"] == "approver"
+
+
+def test_instance_state_is_not_carried_forward(published) -> None:
+    """Deliberately not copied.
+
+    A workflow definition is part of the model; an instance's state is data about a specific
+    contract. Copying it would assert the contract sits at two points in two state machines at
+    once, and reconciling that later needs to know which one the business considers
+    authoritative -- which the platform cannot decide for them.
+    """
+    enter_workflow(published["platform_db"], published["workflow_id"], published["object_code"], "1")
+    derived_id = _derive(published)
+
+    with connect(published["platform_db"]) as conn:
+        derived_workflow = conn.execute(
+            "select id from workflow_definition where ontology_id = ?", (derived_id,)
+        ).fetchone()
+        instances = conn.execute(
+            "select count(*) as total from instance_workflow where workflow_id = ?",
+            (derived_workflow["id"],),
+        ).fetchone()["total"]
+    assert instances == 0, "实例状态不应随定义一起复制"
+
+
+def test_deriving_without_any_workflow_still_succeeds(tmp_path: Path) -> None:
+    """A deployment that never configured a workflow must still be able to derive.
+
+    Zero workflows rather than an error: an absent feature is not a failure.
+    """
+    source = tmp_path / "b.sqlite3"
+    sqlite3.connect(source).executescript("create table t (id integer primary key, name text not null);")
+    platform_db = tmp_path / "p.sqlite3"
+    initialize_platform_db(platform_db)
+    data_source = register_data_source(platform_db, "s", "sqlite", str(source), domain="合同管理")
+    scan_data_source(platform_db, data_source.id)
+    ontology_id = generate_ontology_draft(platform_db, data_source.id)["ontology"]["id"]
+
+    with connect(platform_db) as conn:
+        conn.execute("update semantic_mapping set status = 'confirmed' where ontology_id = ?", (ontology_id,))
+        object_code = conn.execute("select code from business_object where ontology_id = ?", (ontology_id,)).fetchone()[
+            "code"
+        ]
+    # The release gate requires at least one published rule, and that gate is correct: an
+    # ontology that decides nothing is not a semantic kernel. So the fixture satisfies it
+    # rather than working around it.
+    upsert_business_rule(
+        platform_db,
+        ontology_id,
+        "name_required",
+        "名称不能为空",
+        "validation",
+        object_code,
+        "name != null",
+        "blocking",
+        "名称不能为空。",
+        "tester",
+    )
+    publish_ontology(platform_db, ontology_id, "tester")
+
+    derived = derive_ontology_version(platform_db, ontology_id, "0.2.0", "tester")
+    assert derived.get("id") or derived["ontology"]["id"]
+
+
+# -- Rule columns that decide evaluation --
+
+
+def test_rule_columns_that_change_evaluation_are_carried_forward(published) -> None:
+    """These five were dropped, and losing them changes verdicts rather than only metadata.
+
+    `priority` decides evaluation order, the effective dates decide whether a rule applies at
+    all, and `depends_on` is read by the engine. A derived version was therefore evaluating
+    the same rules differently from the one it came from.
+    """
+    derived_id = _derive(published)
+    with connect(published["platform_db"]) as conn:
+        rule = conn.execute(
+            "select priority, category, effective_start, effective_end, depends_on"
+            " from business_rule where ontology_id = ? limit 1",
+            (derived_id,),
+        ).fetchone()
+
+    assert rule is not None, "派生版本缺少规则"
+    assert int(rule["priority"]) == 7, "priority 丢失会改变规则求值顺序"
+    assert rule["category"] == "合规"
+    assert str(rule["effective_start"]) == "2026-01-01", "生效期丢失会让规则在不该生效时生效"
+    assert str(rule["effective_end"]) == "2026-12-31"
+    assert rule["depends_on"] == '["other_rule"]', "depends_on 丢失会改变依赖求值"
+
+
+def test_the_audit_entry_reports_what_was_copied(published) -> None:
+    """ "How much did this derivation carry over" must be answerable after the fact, without
+    diffing two ontologies by hand."""
+    import json
+
+    derived_id = _derive(published)
+    with connect(published["platform_db"]) as conn:
+        row = conn.execute(
+            "select detail from audit_log where action = 'derive_ontology_version' order by id desc"
+        ).fetchone()
+    detail = json.loads(row["detail"])
+    assert detail["newOntologyId"] == derived_id
+    assert detail["workflows"] == 1, "审计未记录复制的工作流数量"
+    assert detail["rules"] >= 1


### PR DESCRIPTION
## `derive` 丢掉的两样东西都会改变判定

派生新本体版本会复制对象、属性、关系、映射、规则。此前丢掉的两样被记在 README「当前限制」里，而它们**都不是丢元数据**。

### 一、工作流定义

派生版本的对象**没有状态机**，于是进入它的实例无处可去。症状是「这个对象没有工作流」——读起来像建模遗漏，而不像 `derive` 丢了东西。

状态与流转一并复制，**含 `guard_expression`、`requires_review`、`review_role`**：guard 正是让一个流转可被拒绝的东西。丢掉它会把每个受限流转变成开放流转，**而流转看起来依然工作**——它只是不再拒绝任何东西。

### 二、五个规则求值列

`priority`、`category`、`effective_start`、`effective_end`、`depends_on`。

这些不是描述性字段：**priority 决定求值顺序、生效期决定规则是否适用、`depends_on` 会被引擎读取**。

所以派生版本会以不同顺序、在不同生效期内求值同一批规则——**「新版本给出不同判定」恰恰是 `derive` 最不该静默做的事**。

读取时容忍列缺失：早于这些列的部署否则会让每次 `derive` 都失败，而**破坏派生的升级比少一个没人设过的列更糟**。

## 实例状态刻意仍不复制

工作流**定义**属于模型；某份合同当前在哪个状态属于**数据**。复制它等于断言这份合同同时处在两个状态机的两个位置上，而事后调和需要知道业务认为哪个才是权威——那是平台无法替他们决定的问题。

## 反例验证

撤回工作流复制后，7 个新测试中有 5 个失败，并指名丢了什么。

## README「字段存在但逻辑未生效」现已清空

这一类最危险，因为接口看起来能用。所以不是删掉这一节，而是**逐项记录它们是如何消失的**——一个没有历史的空章节读起来像是没人维护。

## 验证

3.11／3.12／3.13 各 **1219 通过**。