### PR TITLE
修复 serve --platform-db 服务的不是那个库

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -657,7 +657,7 @@ can be revoked, and changing a password invalidates all existing sessions.
 .venv/bin/python -m pytest
 ```
 
-**1221 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
+**1228 tests**, all passing. Two skip by environment: the MySQL/PostgreSQL cases skip when
 no server is reachable.
 
 | File | Count | Covers |

--- a/README.md
+++ b/README.md
@@ -887,7 +887,16 @@ SHACL 形状由声明生成而非手写——手写的一份会与发布门禁�
 |---|---|---|
 | `ONTOLOGY_PLATFORM_DB_TYPE` | `sqlite`／`mysql`／`postgresql` | `sqlite` |
 | `ONTOLOGY_PLATFORM_DB_URI` | 平台库连接串 | 本地 SQLite 文件 |
+| `ONTOLOGY_PLATFORM_DB_FILE` | 直接指定 SQLite 平台库**文件**（优先于 `ONTOLOGY_DATA_DIR`） | 未设 |
+| `ONTOLOGY_DATA_DIR` | 平台库所在**目录**，文件名固定为 `platform.sqlite3` | 源码树下为 `data/`，否则 `~/.aletheia` |
 | `ONTOLOGY_PLATFORM_SQLITE_BUSY_TIMEOUT_MS` | SQLite busy_timeout | `5000` |
+
+> **`serve` 与其他命令用同一个库。** `aletheia serve --platform-db X` 会把 `X`
+> 传给被服务的进程，并在启动时打印实际使用的路径。
+> 此前它做不到：`uvicorn` 在新进程里导入应用，只能从环境变量解析平台库，
+> 于是 `serve --platform-db X` 服务的是**另一个**库——
+> 而症状是 API 返回空本体列表，读起来像「我的数据没保存」，
+> 于是排查会从重跑 `model`、怀疑写入开始，唯一不像的就是路径不一致。
 
 ### 阈值与命名
 
@@ -942,7 +951,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 .venv/bin/python -m pytest
 ```
 
-**1221 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
+**1228 个测试**，全绿。其中 2 个按环境跳过：无本地 MySQL／PostgreSQL 服务时
 对应用例自动跳过。分布：
 
 | 文件 | 数量 | 覆盖 |
@@ -956,6 +965,7 @@ SQL 差异由 `database.py` 的适配层统一吸收：占位符转换、
 | `test_inert_fields_activated.py` | 28 | 守卫、行级过滤、规则依赖、策略本体维度 |
 | `test_conversations_and_feedback.py` | 35 | 会话持久化、反馈归因、转人工 |
 | `test_platform_context.py` | 23 | 多实例隔离、线程绑定、向后兼容 |
+| `test_platform_db_consistency.py` | 7 | serve 与其他命令用同一个平台库，并在启动时告知路径 |
 | `test_derive_completeness.py` | 7 | 派生新版本复制工作流与规则求值列，但不复制实例状态 |
 | `test_codegen.py` | 16 | 关系类型化为目标对象、仅已发布本体、产物通过真实 tsc --strict |
 | `test_scaffold.py` | 19 | 生成的代码被真实执行：能编译、能注册、能建库、不含平台私有引用 |

--- a/backend/ontology_platform/cli.py
+++ b/backend/ontology_platform/cli.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Optional, Sequence
@@ -412,8 +414,57 @@ def cmd_serve(args: argparse.Namespace) -> int:
                 f"监听地址 {args.host} 可从网络访问，但部署前自检未通过。"
                 "修复上述阻断项，或显式传 --skip-preflight（不建议）。"
             )
-    uvicorn.run("ontology_platform.api:app", host=args.host, port=args.port, reload=args.reload)
-    return 0
+
+    if not args.platform_db:
+        uvicorn.run("ontology_platform.api:app", host=args.host, port=args.port, reload=args.reload)
+        return 0
+
+    # With `--platform-db`, the server has to run in a **child process**.
+    #
+    # `database.DEFAULT_PLATFORM_DB` is a module constant resolved at import time, and `cli`
+    # has already imported `database` by the time it reaches this function. So setting the
+    # environment variable here and calling `uvicorn.run` in-process changes nothing: the
+    # constant was fixed long before, and `api` binds the already-fixed value.
+    #
+    # That was the actual defect, and it failed in the worst available shape. `aletheia init
+    # --platform-db X` followed by `aletheia serve --platform-db X` served a *different*
+    # database, so the API returned an empty ontology list and rejected the administrator
+    # password -- with nothing reporting a mismatch. "Empty results and a rejected login"
+    # reads as "my data did not save", which sends the investigation to the writes rather
+    # than to the path.
+    #
+    # A fresh process is the only way the variable can be observed, because the value is read
+    # once per interpreter. Passing `--platform-db` through to a child rather than asking the
+    # user to export the variable themselves: a flag that silently means something different
+    # from every other command's identical flag is worse than no flag.
+    from .database import PLATFORM_DB_FILE_ENV
+
+    resolved = str(Path(args.platform_db).expanduser().resolve())
+    environment = dict(os.environ)
+    environment[PLATFORM_DB_FILE_ENV] = resolved
+    # Announced because a silent correct default and a silent wrong default look identical
+    # from outside, and this is the value that decides whether a deployment sees its own data.
+    print(f"[serve] 平台库: {resolved}", file=sys.stderr)
+
+    command = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "ontology_platform.api:app",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+    if args.reload:
+        command.append("--reload")
+
+    try:
+        return subprocess.call(command, env=environment)
+    except KeyboardInterrupt:
+        # Ctrl-C reaches both processes; the child handles its own shutdown, and reporting a
+        # traceback here would make a normal stop look like a crash.
+        return 0
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:

--- a/backend/ontology_platform/database.py
+++ b/backend/ontology_platform/database.py
@@ -45,7 +45,37 @@ def _default_data_dir() -> Path:
 
 
 DEFAULT_DATA_DIR = _default_data_dir()
-DEFAULT_PLATFORM_DB = DEFAULT_DATA_DIR / "platform.sqlite3"
+
+# Named as a constant because `cli.serve` sets it to hand the path to the process uvicorn
+# imports. Two copies of the string would drift, and the drift would be silent: `serve` would
+# set a variable nothing reads, restoring the bug it was added to fix.
+PLATFORM_DB_FILE_ENV = "ONTOLOGY_PLATFORM_DB_FILE"
+
+
+def _default_platform_db() -> Path:
+    """The SQLite platform database this process uses.
+
+    `ONTOLOGY_PLATFORM_DB_FILE` names the file directly, which `ONTOLOGY_DATA_DIR` cannot:
+    the directory variable requires the file to be called `platform.sqlite3`, so pointing a
+    process at `/srv/aletheia/prod.sqlite3` was impossible without renaming it.
+
+    That gap had a concrete cost. `aletheia serve --platform-db X` runs uvicorn in a new
+    process, and that process had no way to receive `X` -- so it silently opened the default
+    database instead. A user who had just run `init` and `model` against `X` saw an empty
+    ontology list through the API, with nothing reporting a mismatch. An empty result reads
+    as "my data did not save", which sends the investigation in exactly the wrong direction.
+
+    Precedence is file, then directory, then the checkout/home default: the more specific
+    setting wins, so a deployment can point one process at one database without disturbing
+    the directory layout everything else uses.
+    """
+    override = os.environ.get(PLATFORM_DB_FILE_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_DATA_DIR / "platform.sqlite3"
+
+
+DEFAULT_PLATFORM_DB = _default_platform_db()
 
 _platform_db_type: str = "sqlite"
 _platform_db_uri: str = str(DEFAULT_PLATFORM_DB)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -452,15 +452,27 @@ def test_serve_refuses_to_expose_an_unsafe_deployment(capsys, monkeypatch, tmp_p
 def test_serve_on_loopback_does_not_run_preflight(capsys, monkeypatch, tmp_path) -> None:
     """Local development must stay frictionless, or the check gets disabled globally.
 
-    Verified by patching uvicorn.run: reaching it proves preflight did not intercept.
+    Verified by intercepting the spawn: reaching it proves preflight did not intercept.
+
+    `serve --platform-db X` runs the server in a child process, because
+    `database.DEFAULT_PLATFORM_DB` is resolved at import time and setting the environment
+    variable in-process would change a constant that was already fixed. So the thing to
+    intercept is `subprocess.call`, not `uvicorn.run` -- patching the latter used to work and
+    now lets a real server start, which hangs the suite rather than failing it.
     """
+    from ontology_platform import cli
+
     started: dict[str, object] = {}
     monkeypatch.setenv("ONTOLOGY_AUTH_DISABLED", "1")
-    monkeypatch.setitem(
-        sys.modules,
-        "uvicorn",
-        type("_Fake", (), {"run": staticmethod(lambda app, **kwargs: started.update(kwargs))})(),
-    )
+    monkeypatch.setitem(sys.modules, "uvicorn", object())
+
+    def _fake_call(command, env=None, **kwargs):
+        started["command"] = list(command)
+        return 0
+
+    monkeypatch.setattr(cli.subprocess, "call", _fake_call)
     code, _, _ = _run(capsys, "--platform-db", str(tmp_path / "p.sqlite3"), "serve", "--host", "127.0.0.1")
     assert code == 0
-    assert started.get("host") == "127.0.0.1"
+    command = started.get("command")
+    assert command is not None, "preflight 拦下了本机监听，本地开发会因此产生摩擦"
+    assert "127.0.0.1" in command

--- a/tests/test_platform_db_consistency.py
+++ b/tests/test_platform_db_consistency.py
@@ -1,0 +1,190 @@
+"""`--platform-db` must mean the same database in every command, including `serve`.
+
+Found by using the platform rather than by testing it: `aletheia init --platform-db X`
+followed by `aletheia serve --platform-db X` served a *different* database. `uvicorn.run`
+imports the app in a fresh context that resolves the platform database from the environment,
+and nothing carried `X` across.
+
+The failure mode is what makes this worth a dedicated test. Nothing errored. The API returned
+an empty ontology list, which reads as "my data did not save" -- so the investigation starts
+by re-running `model`, re-checking the scan, and doubting the writes. The one thing it does
+not look like is a path mismatch.
+
+Two properties are pinned here:
+
+- **the flag reaches the served process**, so every command agrees on the database
+- **the path is announced on startup**, because a silent correct default and a silent wrong
+  default are indistinguishable from outside, and this is the variable that decides whether
+  a deployment sees its own data
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+
+def _env(**overrides: str) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(ROOT / "backend")
+    # Cleared so the test observes the resolution rules rather than the developer's shell.
+    for name in ("ONTOLOGY_PLATFORM_DB_FILE", "ONTOLOGY_DATA_DIR"):
+        environment.pop(name, None)
+    environment.update(overrides)
+    return environment
+
+
+def _resolved_platform_db(environment: dict[str, str]) -> str:
+    """The path a freshly imported process would use.
+
+    A subprocess because the value is resolved at import time: reading it in-process would
+    report whatever the first import happened to see.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from ontology_platform.database import DEFAULT_PLATFORM_DB; print(DEFAULT_PLATFORM_DB)",
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+# -- The file-level override --
+
+
+def test_the_file_variable_names_the_database_directly(tmp_path: Path) -> None:
+    """`ONTOLOGY_DATA_DIR` cannot express this.
+
+    The directory variable requires the file to be called `platform.sqlite3`, so pointing a
+    process at `/srv/aletheia/prod.sqlite3` was impossible without renaming it.
+    """
+    target = tmp_path / "prod.sqlite3"
+    assert _resolved_platform_db(_env(ONTOLOGY_PLATFORM_DB_FILE=str(target))) == str(target)
+
+
+def test_the_file_variable_wins_over_the_directory(tmp_path: Path) -> None:
+    """The more specific setting wins, so a deployment can point one process at one database
+    without disturbing the directory layout everything else uses."""
+    directory = tmp_path / "data"
+    target = tmp_path / "explicit.sqlite3"
+    resolved = _resolved_platform_db(_env(ONTOLOGY_DATA_DIR=str(directory), ONTOLOGY_PLATFORM_DB_FILE=str(target)))
+    assert resolved == str(target)
+
+
+def test_the_directory_variable_still_works_alone(tmp_path: Path) -> None:
+    """Existing deployments configure the directory, and this must not change for them."""
+    directory = tmp_path / "data"
+    resolved = _resolved_platform_db(_env(ONTOLOGY_DATA_DIR=str(directory)))
+    assert resolved == str(directory / "platform.sqlite3")
+
+
+# -- `serve` carries the flag across the process boundary --
+
+
+def test_serve_passes_the_flag_to_the_served_process(tmp_path: Path, monkeypatch) -> None:
+    """The defect this file exists for.
+
+    `serve --platform-db X` runs the server in a child process, because
+    `database.DEFAULT_PLATFORM_DB` is resolved at import time and `cli` has already imported
+    `database` by then -- setting the variable in-process changes a constant that was fixed
+    long before. Only a fresh interpreter can observe it.
+
+    Asserted by intercepting the spawn rather than by starting a server and querying it: a
+    real server would add a port, several seconds and a class of failures that have nothing
+    to do with the path under test.
+    """
+    from ontology_platform import cli
+    from ontology_platform.database import PLATFORM_DB_FILE_ENV
+
+    target = tmp_path / "mine.sqlite3"
+    observed: dict[str, object] = {}
+
+    def _fake_call(command, env=None, **kwargs):
+        observed["command"] = command
+        observed["platformDb"] = (env or {}).get(PLATFORM_DB_FILE_ENV)
+        return 0
+
+    monkeypatch.setattr(cli.subprocess, "call", _fake_call)
+    monkeypatch.setitem(sys.modules, "uvicorn", object())
+
+    parser = cli.build_parser()
+    args = parser.parse_args(["--platform-db", str(target), "serve", "--host", "127.0.0.1"])
+    assert cli.cmd_serve(args) == 0
+
+    assert observed["platformDb"] == str(target.expanduser().resolve()), (
+        "serve 未把 --platform-db 传给被服务的进程：它会读另一个库，"
+        "而症状是本体列表为空、管理员口令被拒——读起来像「数据没保存」"
+    )
+    command = observed["command"]
+    assert "ontology_platform.api:app" in command
+    assert "--host" in command and "127.0.0.1" in command
+
+
+def test_serve_without_the_flag_runs_in_process_and_keeps_the_environment(tmp_path: Path, monkeypatch) -> None:
+    """No flag means no child process and no environment change.
+
+    A deployment that configured `ONTOLOGY_PLATFORM_DB_FILE` and did not pass the flag must
+    keep its setting -- substituting one silent mismatch for another would be no improvement.
+    Running in-process also keeps the common case free of a second interpreter.
+    """
+    from ontology_platform import cli
+    from ontology_platform.database import PLATFORM_DB_FILE_ENV
+
+    configured = str(tmp_path / "configured.sqlite3")
+    monkeypatch.setenv(PLATFORM_DB_FILE_ENV, configured)
+
+    spawned: list[object] = []
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: spawned.append(a) or 0)
+
+    in_process: dict[str, object] = {}
+
+    class _Recorder:
+        @staticmethod
+        def run(app: str, **kwargs: object) -> None:
+            in_process["app"] = app
+
+    monkeypatch.setitem(sys.modules, "uvicorn", _Recorder())
+
+    parser = cli.build_parser()
+    assert cli.cmd_serve(parser.parse_args(["serve", "--host", "127.0.0.1"])) == 0
+
+    assert in_process["app"] == "ontology_platform.api:app", "未传 --platform-db 时应在本进程内启动"
+    assert not spawned, "未传 --platform-db 时不应另起进程"
+    assert os.environ[PLATFORM_DB_FILE_ENV] == configured, "不应改写已配置的环境变量"
+
+
+def test_serve_announces_the_database_it_will_use(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A silent correct default and a silent wrong default look identical from outside.
+
+    This is the value that decides whether a deployment sees its own data, so it is printed
+    rather than left to be inferred from an empty result.
+    """
+    from ontology_platform import cli
+
+    target = tmp_path / "announced.sqlite3"
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 0)
+    monkeypatch.setitem(sys.modules, "uvicorn", object())
+
+    parser = cli.build_parser()
+    cli.cmd_serve(parser.parse_args(["--platform-db", str(target), "serve", "--host", "127.0.0.1"]))
+
+    assert str(target.resolve()) in capsys.readouterr().err, "serve 未告知实际使用的平台库"
+
+
+# -- The documented variable list stays honest --
+
+
+def test_the_new_variable_is_documented() -> None:
+    """A resolution rule nobody can find is a rule that gets rediscovered by debugging."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "ONTOLOGY_PLATFORM_DB_FILE" in readme, "README 未记录该环境变量"


### PR DESCRIPTION
## 用出来的缺陷，不是测出来的

`aletheia init --platform-db X` 之后 `aletheia serve --platform-db X`，服务读的是**另一个库**：API 返回空本体列表、管理员口令被拒，而**没有任何东西报告不一致**。

这个失败形态才是关键。「结果为空 + 登录被拒」读起来像「我的数据没保存」，于是排查会从重跑 `model`、重查扫描、怀疑写入开始。**唯一不像的就是路径不一致**——而 `--platform-db` 被无声接受，这让那个方向更可信。

## 第一次修复看起来对，实际无效

`database.DEFAULT_PLATFORM_DB` 是 **import 期求值的模块常量**，而 `cli` 在进入 `cmd_serve` 之前早已导入 `database`。

所以「设环境变量，然后调 `uvicorn.run`」什么也没改变：常量早就固定了，`api` 绑定的是已固定的值。

我是**实测发现的**——第一版改完日志打印正确、登录依然 401，才去直接验证常量绑定时机，而不是假设它生效。

## 正确修法：带 `--platform-db` 时起子进程

新进程是那个变量唯一能被观察到的上下文。不带该 flag 时仍在本进程内启动，所以常见路径不用多付一个解释器的代价，且**自行配置了 `ONTOLOGY_PLATFORM_DB_FILE` 的部署保持原设置**。

## 为什么需要新环境变量

`ONTOLOGY_DATA_DIR` 表达不了这件事：它要求文件名固定为 `platform.sqlite3`，于是把某个进程指向 `/srv/aletheia/prod.sqlite3` 必须先改名。

优先级：文件 → 目录 → 源码树／home 默认值。

## 启动时打印路径

**静默的正确默认值与静默的错误默认值，从外部看完全一样**。而这个值决定一个部署能否看到自己的数据。

## 一个既有测试必须改，不能绕

`test_serve_on_loopback_does_not_run_preflight` 通过 mock `uvicorn.run` 证明 preflight 不拦本机监听。那个 mock 现在**不在代码路径上**了——于是它让一个真实服务启动，**把测试套件挂住而不是让它失败**。改为拦截进程启动。

## 验证

真实服务端到端：`serve --platform-db X` 打印路径、登录成功、`/ontologies` 列出 CLI 建的本体、判定返回 `approved`。

3.11／3.12／3.13 各 **1226 通过**，无挂起、无残留进程。